### PR TITLE
Use service tenant name not id in capacity check

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -642,9 +642,9 @@ class OSCapacityCheck():
     public_network_id = nagios_test_router[0]['external_gateway_info']['network_id']
     '''
 
-    SERVICE_TENANT_ID="service"
+    SERVICE_TENANT_NAME="service"
     PUBLIC_NET_NAME="public"
-    public_network_id = self.neutron.list_networks(tenant_id=SERVICE_TENANT_ID,
+    public_network_id = self.neutron.list_networks(tenant_name=SERVICE_TENANT_NAME,
                          name=PUBLIC_NET_NAME)['networks'][0]['id']
 
     # Our public IP's are used for routers in addition to instances so we must


### PR DESCRIPTION
Fix an issue that was preventing check_openstack from working when the
service tenant id was something other than "service".

When filtering for the public provider network it should not be searched
for based on id. The id can change based on environment and can't be
assumed to always be the same as was the case previously. With this
patch we make a slightly less bad assumption that the service tenant is
always named "service".
