### PR TITLE
Use tenant_id instead of tenant_name for public network lookup

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -644,7 +644,7 @@ class OSCapacityCheck():
 
     SERVICE_TENANT_NAME="service"
     PUBLIC_NET_NAME="public"
-    public_network_id = self.neutron.list_networks(tenant_name=SERVICE_TENANT_NAME,
+    public_network_id = self.neutron.list_networks(tenant_id=SERVICE_TENANT_NAME,
                          name=PUBLIC_NET_NAME)['networks'][0]['id']
 
     # Our public IP's are used for routers in addition to instances so we must


### PR DESCRIPTION
Upgrade novaclient from v1_1 to v2.0. Pass hardcoded version
to capacity checks. Use tenant_id instead of tenant_name to
get proper network UUID.
