### PR TITLE
Add RabbitMQ monitoring scripts

### DIFF
--- a/files/nrpe/check_rabbitmq_aliveness
+++ b/files/nrpe/check_rabbitmq_aliveness
@@ -1,0 +1,255 @@
+#!/usr/bin/env perl
+
+###  check_rabbitmq_aliveness.pl
+
+# Use the management aliveness-check to send/receive a message through a vhost
+
+# Originally by Nathan Vonnahme, n8v at users dot sourceforge
+# dot net, July 19 2006
+
+##############################################################################
+# prologue
+use strict;
+use warnings;
+
+use Monitoring::Plugin;
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management aliveness-check to send/receive a message through a vhost.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'vhost=s',
+    help => "Specify the vhost to test (default: %s)",
+    default => "/"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+my $vhost=uri_escape($p->opts->vhost);
+
+my $url = sprintf("http%s://%s:%d/api/aliveness-test/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost);
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
+my $res = $ua->request($req);
+
+if (!$res->is_success) {
+    # Deal with standard error conditions - make the messages more sensible
+    if ($res->code == 400) {
+        my $bodyref = decode_json $res->content;
+        $p->nagios_exit(CRITICAL, $bodyref->{'reason'});
+    }
+    $res->code == 404 and $p->nagios_die("Not found: ".$p->opts->vhost);
+    $res->code == 401 and $p->nagios_die("Access refused: ".$p->opts->vhost);
+    if ($res->code < 200 or $res->code > 400 ) {
+        $p->nagios_exit(CRITICAL, "Received ".$res->status_line." for vhost: ".$p->opts->vhost);
+    }
+}
+
+my $bodyref = decode_json $res->content;
+$bodyref->{'status'} eq "ok" or $p->nagios_exit(CRITICAL, $res->content);
+my($code, $message) = (OK, "vhost: ".$p->opts->vhost);
+$p->nagios_exit(
+    return_code => $code,
+    message => $message
+);
+
+=head1 NAME
+
+check_rabbitmq_aliveness - Nagios plugin using RabbitMQ management API to
+check liveness by send/receive a message through a vhost
+
+=head1 SYNOPSIS
+
+check_rabbitmq_aliveness [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check that the server is alive.
+It declares a test queue, then publishes and consumes a message.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --vhost
+
+The vhost to create the test queue within (default: /)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_aliveness -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_ALIVENESS OK - vhost: /
+
+You can choose a different vhost to use for the check also:
+
+    check_rabbitmq_aliveness -H rabbit.example.com --vhost /foo
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_cluster
+++ b/files/nrpe/check_rabbitmq_cluster
@@ -1,0 +1,329 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_cluster
+#
+# Use the management API to check how many node are alived in the cluster.
+
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to check how many node are in the cluster',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(spec => 'nodes|n=s',
+    help => "Comma separated list of expected nodes in the cluster",
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD]]
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD]]
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify 1 to 3 ranges for --warning argument") unless $#warning < 3;
+
+    $warning{'nb_running_node'} = shift @warning;
+    $warning{'nb_running_disc_node'} = shift @warning;
+    $warning{'nb_running_ram_node'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify specify 1 to 3 ranges for --critical argument") unless $#critical < 3;
+
+    $critical{'nb_running_node'} = shift @critical;
+    $critical{'nb_running_disc_node'} = shift @critical;
+    $critical{'nb_running_ram_node'} = shift @critical;
+}
+
+# check stuff.
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $url = sprintf("http%s://%s:%d/api/nodes", ($p->opts->ssl ? "s" : ""), $hostname, $port);
+my $ua = LWP::UserAgent->new;
+
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my ($retcode, $result) = request($url);
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : $url");
+}
+
+my $values = {};
+$values->{'running_nodes'} = ();
+$values->{'nb_running_node'} = 0;
+$values->{'nb_running_disc_node'} = 0;
+$values->{'nb_running_ram_node'} = 0;
+
+foreach my $node ( @$result ) {
+    if ($node->{"name"} && $node->{"running"}) {
+        push @{ $values->{'running_nodes'} }, $node->{"name"};
+
+        $values->{'nb_running_node'}++;
+        $values->{'nb_running_disc_node'}++ if ($node->{"type"} && $node->{"type"} eq "disc");
+        $values->{'nb_running_ram_node'}++ if ($node->{"type"} && $node->{"type"} eq "ram");
+    }
+}
+
+my $code = 0;
+my $message = "";
+
+if (defined($p->opts->nodes)) {
+    my @nodes = split(',', $p->opts->nodes);
+    my @excluded_nodes = diff(\@nodes, \@{ $values->{'running_nodes'} });
+    my $nb_excluded_nodes = @excluded_nodes;
+    ($code, $message) = (OK, "All nodes are running");
+    ($code, $message) = (CRITICAL, "$nb_excluded_nodes failed cluster node: " . join(',', @excluded_nodes)) if($nb_excluded_nodes ne 0);
+}
+else {
+    my @metrics = ("nb_running_node", "nb_running_disc_node", "nb_running_ram_node");
+    for my $metric (@metrics) {
+        my $warning = undef;
+        $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} ne -1);
+        
+        my $critical = undef;
+        $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
+
+        my $value = 0;
+        $value = $values->{$metric} if defined $values->{$metric};
+        my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+        $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value));
+    }
+    ($code, $message) = $p->check_messages(join_all=>', ');
+}
+
+$p->nagios_exit(return_code => $code, message => $message);
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+sub diff {
+    my ($array_1, $array_2) = (@_);
+    return grep { my $baz = $_; grep($_ ne $baz, @$array_2) } @$array_1;
+}
+
+=head1 NAME
+
+check_rabbitmq_cluster - Nagios plugin using RabbitMQ management API to check how many node are alived in the cluster
+
+=head1 SYNOPSIS
+
+check_rabbitmq_cluster [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check if a cluster partition has occured.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_cluster -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_CLUSTER OK - The cluster has 3 nodes
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+Thierno IB. BARRY
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_connections
+++ b/files/nrpe/check_rabbitmq_connections
@@ -1,0 +1,343 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_connections
+#
+# Use the management APIs to check amount of connections
+#
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to monitor connections.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+$p->add_arg(
+    spec => 'clientuser=s',
+    help => 'Specify the client username to limit the connections for (optional)',
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify 1 to 4 ranges for --warning argument") unless $#warning < 4;
+
+    $warning{'connections'} = shift @warning;
+    $warning{'connections_notrunning'} = shift @warning;
+    $warning{'receive_rate'} = shift @warning;
+    $warning{'send_rate'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify specify 1 to 4 ranges for --critical argument") unless $#critical < 4;
+
+    $critical{'connections'} = shift @critical;
+    $critical{'connections_notrunning'} = shift @critical;
+    $critical{'receive_rate'} = shift @critical;
+    $critical{'send_rate'} = shift @critical;
+}
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my $url = sprintf("http%s://%s:%d/api/connections", ($p->opts->ssl ? "s" : ""), $hostname, $port);
+my ($retcode, $result) = request($url);
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : $url");
+}
+
+my $values = {};
+$values->{'connections'} = 0;
+$values->{'connections_notrunning'} = 0;
+$values->{'receive_rate'} = 0;
+$values->{'send_rate'} = 0;
+
+for my $connection (@$result) {
+    if (not defined($p->opts->clientuser) or $p->opts->clientuser eq $connection->{"user"}) {
+        $values->{'connections'}++;
+        $values->{'connections_notrunning'}++ if $connection->{"state"} ne "running";
+        $values->{'receive_rate'} += $connection->{"recv_oct_details"}->{"rate"};
+        $values->{'send_rate'} += $connection->{"send_oct_details"}->{"rate"};
+    }
+}
+
+my @metrics = ("connections", "connections_notrunning", "receive_rate", "send_rate");
+for my $metric (@metrics) {
+    my $warning = undef;
+    $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} ne -1);
+    my $critical = undef;
+    $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
+
+    my $value = 0;
+    $value = $values->{$metric} if defined $values->{$metric};
+    my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+    $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
+    $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
+}
+
+my ($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit(return_code => $code, message => $message);
+
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_connections - Nagios plugin using RabbitMQ management API to
+count the connections running, their state and optionally limit these checks to
+specific connected client user accounts.
+
+=head1 SYNOPSIS
+
+check_rabbitmq_connections [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to count the number of established
+connections, those that are not in state running and also their throughput. All
+values are published as performance metrics for the check.
+
+Critical and warning thresholds can be set for each of the metric.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=item -w | --warning
+
+The warning levels for each count of connections established, connections
+in a non-running state (flow, blocked), receive rate and send rate.  This
+field consists of one to four comma-separated thresholds.  Specify -1 if
+no threshold for a particular count.
+
+=item -c | --critical
+
+The critical levels for each count of connections established, connections
+in a non-running state (flow, blocked), receive rate and send rate. This
+field consists of one to four comma-separated thresholds.  Specify -1 if
+no threshold for a particular count.
+
+=item --clientuser
+
+Specify the client username to limit the connections checks for.
+
+=back
+
+=head1 THRESHOLD FORMAT
+
+The format of thresholds specified in --warning and --critical arguments
+is defined at <http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT>.
+
+For example to be crtical if more than 5 connections, more than 2 connections not running,
+less than 200b/s received use
+
+--critical=5,2,200,-1
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_connections -H localhost -w 1: -c 1:
+
+This returns a standard Nagios result:
+
+  RABBITMQ_CONNECTIONS CRITICAL - connections CRITICAL (0),
+    connections_notrunning WARNING (0), receive_rate OK (0) send_rate OK (0) |
+    connections=0;;1: connections_notrunning=0;1:; receive_rate=0;; send_rate=0;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_exchange
+++ b/files/nrpe/check_rabbitmq_exchange
@@ -1,0 +1,326 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_exchange
+#
+# Use the management APIs to check an exchange
+#
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname --exchange exchange --period period",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to monitor a specific exchange.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'vhost=s',
+    help => "Specify the vhost where the exchange resides (default: %s)",
+    default => "/"
+);
+$p->add_arg(spec => 'exchange=s',
+    help => "Specify the exchange to check",
+    required => 1
+);
+
+$p->add_arg(spec => 'period=s',
+    help => "Specify the time period for which you want to check the thresholds",
+    required => 1
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD]]
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD]]
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify 1 to 3 ranges for --warning argument") unless $#warning < 3;
+
+    $warning{'confirm'} = shift @warning;
+    $warning{'publish_in'} = shift @warning;
+    $warning{'publish_out'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify 1 to 3 ranges for --critical argument") unless $#critical < 3;
+
+    $critical{'confirm'} = shift @critical;
+    $critical{'publish_in'} = shift @critical;
+    $critical{'publish_out'} = shift @critical;
+}
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+my $vhost=uri_escape($p->opts->vhost);
+my $exchange=$p->opts->exchange;
+my $timePeriod=$p->opts->period;
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my $url = sprintf("http%s://%s:%d/api/exchanges/%s/%s?msg_rates_age=%s&msg_rates_incr=%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $exchange, $timePeriod, $timePeriod);
+my ($retcode, $result) = request($url);
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : $url");
+}
+
+my @metrics = ("confirm", "publish_in", "publish_out");
+for my $metric (@metrics) {
+    my $warning = undef;
+    $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} ne -1);
+    my $critical = undef;
+    $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
+
+    my $value = 0;
+    $value = $result->{"message_stats"}->{$metric."_details"}->{"avg_rate"} if defined $result->{"message_stats"}->{$metric . "_details"}->{"avg_rate"};
+    my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+    $p->add_message($code, sprintf("$metric"."_avg_rate ".$STATUS_TEXT{$code}." (%f)", $value)) ;
+    $p->add_perfdata(label=>$metric."_avg_rate", value => $value, warning=>$warning, critical=> $critical);
+}
+
+my ($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit(return_code => $code, message => $message);
+
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_exchange - Nagios plugin using RabbitMQ management API to
+check the average rate of messages per second during a given period of time on a given exchange
+
+=head1 SYNOPSIS
+
+check_rabbitmq_overview [options] -H hostname --queue exchange --period period
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to get the average rate of confirmed,
+published in and published out messages per second in a given period of time.  These are
+published as performance metrics for the check.
+
+Critical and warning thresholds can be set for each of the metrics.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=item -w | --warning
+
+The warning levels for each average rate of confirmed, published_in and
+published_out messages per second for the given period of time.  This field consists of
+one to three comma-separated thresholds.  Specify -1 if no threshold
+for a particular average rate.
+
+=item -c | --critical
+
+The critical levels for each average rate of confirmed, published_in and
+published_out messages per second for the given period of time.  This field consists of
+one to four comma-separated thresholds.  Specify -1 if no threshold
+for a particular average rate.
+
+=back
+
+=head1 THRESHOLD FORMAT
+
+The format of thresholds specified in --warning and --critical arguments
+is defined at <http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT>.
+
+For example, to be crtical if average rates are less than 2 messages confirmed per second, less than 2 published_in messages per second,
+or less than 4 published_out messages per second use
+
+--critical=2:,2:,4:
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_exchange -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_OVERVIEW OK - confirm_avg_rate OK (2.5) publish_in_avg_rate OK (2.5)
+      publish_out_avg_rate OK (5) | confirm_avg_rate=2.5;;
+      publish_in_avg_rate=2.5;; publish_out_avg_rate=5;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+Maria Fernandez
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_objects
+++ b/files/nrpe/check_rabbitmq_objects
@@ -1,0 +1,261 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_objects
+#
+# Use the management APIs to count various server objects -
+# vhost, exchange, binding, queue, channel
+#
+use strict;
+use warnings;
+
+use Monitoring::Plugin;
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management to count various objects.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my @calls = ("vhost", "exchange", "binding", "queue", "channel");
+for my $call (@calls) {
+    my $url = sprintf("http%s://%s:%d/api/%ss", ($p->opts->ssl ? "s" : ""), $hostname, $port, $call);
+    my ($code, $result) = request($url);
+    if ($code != 200) {
+        $p->nagios_exit(CRITICAL, "$result : /api/". $call."s");
+    }
+    # we're always returned a list - count it
+    my $count = $#{$result};
+    $count = 0 if $count == -1;
+    $p->add_message(OK, sprintf("$call (%.2f%%)", $count)) ;
+    $p->add_perfdata(label=>$call, value => $count);
+
+}
+
+$p->nagios_exit(return_code => OK, message => "Gathered Object Counts");
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_objects - Nagios plugin using RabbitMQ management API to
+count the number of various broker objects
+
+=head1 SYNOPSIS
+
+check_rabbitmq_objects [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to count the number of various
+broker objects.  These are published as performance metrics for the check.
+
+Currently the following objects are counted:
+
+=over
+
+=item * vhost
+
+=item * exchange
+
+=item * binding
+
+=item * queue
+
+=item * channel
+
+=back
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_objects -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_OBJECTS OK - Gathered Object Counts | vhost=1;; exchange=7;;
+      binding=2;; queue=1;; channel=0;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_overview
+++ b/files/nrpe/check_rabbitmq_overview
@@ -1,0 +1,305 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_overview
+#
+# Use the management APIs to count pending messages in broker
+#
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management to count messages in server.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=INTEGER,INTEGER,INTEGER
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=INTEGER,INTEGER,INTEGER
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify three ranges for --warning argument") unless $#warning == 2;
+
+    $warning{'messages'} = shift @warning;
+    $warning{'messages_ready'} = shift @warning;
+    $warning{'messages_unacknowledged'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify three ranges for --critical argument") unless $#critical == 2;
+
+    $critical{'messages'} = shift @critical;
+    $critical{'messages_ready'} = shift @critical;
+    $critical{'messages_unacknowledged'} = shift @critical;
+}
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my $url = sprintf("http%s://%s:%d/api/overview", ($p->opts->ssl ? "s" : ""), $hostname, $port);
+my ($retcode, $result) = request($url);
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : /api/overview");
+}
+
+my @metrics = ( "messages", "messages_ready", "messages_unacknowledged");
+for my $metric (@metrics) {
+    my $warning = undef;
+    $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} != -1);
+    my $critical = undef;
+    $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} != -1);
+
+    if (ref($result->{'queue_totals'}) eq "HASH") {
+        my $value = $result->{'queue_totals'}->{$metric};
+        my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+        $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
+        $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
+    }
+}
+
+my ($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit(return_code => $code, message => $message);
+
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_overview - Nagios plugin using RabbitMQ management API to
+count the messages pending on the broker
+
+=head1 SYNOPSIS
+
+check_rabbitmq_overview [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to count the number of pending,
+ready and unacknowledged messages.  These are published as performance
+metrics for the check.
+
+Critical and warning thresholds can be set for each of the metrics.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=item -w | --warning
+
+The warning levels for each count of messages, messages_ready and
+messages_unacknowledged.  This field consists of three comma-separated
+integers.  Specify -1 if no threshold for a particular count.
+
+=item -c | --critical
+
+The critical levels for each count of messages, messages_ready and
+messages_unacknowledged.  This field consists of three comma-separated
+integers.  Specify -1 if no threshold for a particular count
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_overview -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_OVERVIEW OK - messages OK (25794) messages_ready OK (22971)
+      messages_unacknowledged OK (2823) | messages=25794;;
+      messages_ready=22971;; messages_unacknowledged=2823;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_partition
+++ b/files/nrpe/check_rabbitmq_partition
@@ -1,0 +1,267 @@
+#!/usr/bin/env perl
+
+###  check_rabbitmq_partition
+
+# Use the management API to check if partitions error conditions exist.
+
+# baseed on check_rabbitmq_watermark.pl,
+# Originally by Nathan Vonnahme, n8v at users dot sourceforge
+# dot net, July 19 2006
+
+##############################################################################
+# prologue
+use strict;
+use warnings;
+
+use Monitoring::Plugin;
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to check if the mem_alarm has been triggered',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+$p->add_arg(spec => 'node|n=s',
+    help => "Specify the node name (default is hostname)"
+);
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(spec => 'rname|r=s',
+    help => "RabbitName (default: %s)",
+    default => "rabbit",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+
+my $nodename = $p->opts->node;
+
+my $rname = $p->opts->rname;
+
+if (!$nodename) {
+    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $nodename = $1;
+}
+
+my $url = sprintf("http%s://%s:%d/api/nodes/%s\@%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $rname, $nodename);
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
+my $res = $ua->request($req);
+
+if (!$res->is_success) {
+    # Deal with standard error conditions - make the messages more sensible
+    if ($res->code == 400) {
+        my $bodyref = decode_json $res->content;
+        $p->nagios_exit(CRITICAL, $bodyref->{'reason'});
+    }
+    $res->code == 404 and $p->nagios_die("Not found");
+    $res->code == 401 and $p->nagios_die("Access refused");
+    if ($res->code < 200 or $res->code > 400 ) {
+        $p->nagios_exit(CRITICAL, "Received ".$res->status_line);
+    }
+}
+my $bodyref = decode_json $res->content;
+
+my $partitions=$bodyref->{'partitions'};
+ref($partitions) eq "ARRAY" or $p->nagios_exit(CRITICAL, $res->content);
+scalar(@$partitions)==0 or $p->nagios_exit(CRITICAL, "Partitions detected: @$partitions");
+
+my($code, $message) = (OK, "No Partitions");
+$p->nagios_exit(
+    return_code => $code,
+    message => $message
+);
+
+=head1 NAME
+
+check_rabbitmq_partition - Nagios plugin using RabbitMQ management API to check if a cluster partition has occured
+
+=head1 SYNOPSIS
+
+check_rabbitmq_partition [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check if a cluster partition has occured.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item -n | --node
+
+The node name (default is hostname)
+
+=item -r | --rname
+
+The rabbit name (default is rabbit)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_node -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_NODE OK - No Partitions
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_queue
+++ b/files/nrpe/check_rabbitmq_queue
@@ -1,0 +1,383 @@
+#!/usr/bin/env perl
+#
+# check_rabbitmq_overview
+#
+# Use the management APIs to check a queue
+#
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname --queue queue",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to monitor a specific queue.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'vhost=s',
+    help => "Specify the vhost where the queue resides (default: %s)",
+    default => "/"
+);
+$p->add_arg(spec => 'queue=s',
+    help => "Specify the queue to check (default: %s)",
+    default => "all"
+);
+
+$p->add_arg(spec => 'filter=s',
+    help => "Specify the queues to filter for the check. It's a perl regex (default: %s)",
+    default => ".*"
+);
+
+
+$p->add_arg(
+    spec => 'warning|w=s',
+    help =>
+qq{-w, --warning=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Warning thresholds specified in order that the metrics are returned.
+   Specify -1 if no warning threshold.},
+
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=THRESHOLD[,THRESHOLD[,THRESHOLD[,THRESHOLD]]]
+   Critical thresholds specified in order that the metrics are returned.
+   Specify -1 if no critical threshold.},
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(spec => 'ignore|ignore!',
+    help => "Ignore alerts if queue does not exist (default: false)",
+    default => 0
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+my %warning;
+if (defined $p->opts->warning) {
+    my @warning = split(',', $p->opts->warning);
+    $p->nagios_die("You should specify 1 to 4 ranges for --warning argument") unless $#warning < 4;
+
+    $warning{'messages'} = shift @warning;
+    $warning{'messages_ready'} = shift @warning;
+    $warning{'messages_unacknowledged'} = shift @warning;
+    $warning{'consumers'} = shift @warning;
+}
+
+my %critical;
+if (defined $p->opts->critical) {
+    my @critical = split(',', $p->opts->critical);
+    $p->nagios_die("You should specify specify 1 to 4 ranges for --critical argument") unless $#critical < 4;
+
+    $critical{'messages'} = shift @critical;
+    $critical{'messages_ready'} = shift @critical;
+    $critical{'messages_unacknowledged'} = shift @critical;
+    $critical{'consumers'} = shift @critical;
+}
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+my $vhost=uri_escape($p->opts->vhost);
+my $queue=$p->opts->queue;
+my $filter=$p->opts->filter;
+my $ignore=$p->opts->ignore;
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+
+my $url = "";
+if ($queue eq "all"){
+    $url = sprintf("http%s://%s:%d/api/queues/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost);
+} else{
+    $url = sprintf("http%s://%s:%d/api/queues/%s/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $vhost, $queue);
+}
+my ($retcode, $result) = request($url);
+if ($retcode == 404 && $ignore) {
+    $p->nagios_exit(OK, "$result : $url");
+}
+if ($retcode != 200) {
+    $p->nagios_exit(CRITICAL, "$result : $url");
+}
+
+my @values = ();
+my @metrics = ("messages", "messages_ready", "messages_unacknowledged", "consumers");
+
+for my $metric (@metrics) {
+    my $warning = undef;
+    $warning = $warning{$metric} if (defined $warning{$metric} and $warning{$metric} ne -1);
+    my $critical = undef;
+    $critical = $critical{$metric} if (defined $critical{$metric} and $critical{$metric} ne -1);
+    if(ref($result) eq 'ARRAY'){
+        my $message = "";
+        my $nb_matched_queues = 0;
+        my $sum_metric_value = 0;
+        for my $queue (@$result){
+            next if $queue->{name} !~ /$filter/i;
+            my $value = 0;
+            $value = $queue->{$metric} if defined $queue->{$metric};
+            my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+            push @values, $code;
+            
+            $nb_matched_queues++;
+            $sum_metric_value += $value;
+            
+            $p->add_message($code, sprintf("$queue->{name} : $metric ".$STATUS_TEXT{$code}." (%d)", $value)) unless $code == 0;
+        }
+        $p->add_perfdata(label=>$metric, value=>sprintf("%.4f", $sum_metric_value/$nb_matched_queues), warning=>$warning, critical=> $critical);
+    } else{
+        my $value = 0;
+        $value = $result->{$metric} if defined $result->{$metric};
+        my $code = $p->check_threshold(check => $value, warning => $warning, critical=> $critical);
+        push @values, $code;
+        
+        $p->add_message($code, sprintf("$metric ".$STATUS_TEXT{$code}." (%d)", $value)) ;
+        $p->add_perfdata(label=>$metric, value => $value, warning=>$warning, critical=> $critical);
+    }
+}
+$p->add_message(0, sprintf("All queues under the thresholds")) unless grep {$_ > 0} @values;
+
+my ($code, $message) = $p->check_messages(join_all=>', ');
+
+$code = 1 if grep /1/,@values;
+$code = 2 if grep /2/,@values;
+
+$p->nagios_exit(return_code => $code, message => $message);
+
+
+sub request {
+    my ($url) = @_;
+    my $req = HTTP::Request->new(GET => $url);
+    $req->authorization_basic($p->opts->username, $p->opts->password);
+    my $res = $ua->request($req);
+
+    if (!$res->is_success) {
+        # Deal with standard error conditions - make the messages more sensible
+        if ($res->code == 400) {
+            my $bodyref = decode_json $res->content;
+            return (400, $bodyref->{'reason'});
+
+        }
+        $res->code == 404 and return (404, "Not Found");
+        $res->code == 401 and return (401, "Access Refused");
+        $res->status_line =~ /Can\'t connect/ and return (500, "Connection Refused : $url");
+        if ($res->code < 200 or $res->code > 400 ) {
+            return ($res->code, "Received ".$res->status_line);
+        }
+    }
+    my $bodyref = decode_json $res->content;
+    return($res->code, $bodyref);
+}
+
+=head1 NAME
+
+check_rabbitmq_queue - Nagios plugin using RabbitMQ management API to
+count the messages pending and consumers on a given queue
+
+=head1 SYNOPSIS
+
+check_rabbitmq_queue [options] -H hostname --queue queue
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to count the number of pending,
+ready and unacknowledged messages and number of consumers.  These are
+published as performance metrics for the check.
+
+Critical and warning thresholds can be set for each of the metrics.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item --password | -p
+
+The password for the user (default: guest)
+
+=item -w | --warning
+
+The warning levels for each count of messages, messages_ready,
+messages_unacknowledged and consumers.  This field consists of
+one to four comma-separated thresholds.  Specify -1 if no threshold
+for a particular count.
+
+=item -c | --critical
+
+The critical levels for each count of messages, messages_ready,
+messages_unacknowledged and consumers.  This field consists of
+one to four comma-separated thresholds.  Specify -1 if no threshold
+for a particular count.
+
+=item --ignore
+
+If the queue specified does not exist, this option ignores 
+CRITICAL alerts and returns a status of OK.  Useful for scenarios
+where queue existence is optional.
+
+=back
+
+=head1 THRESHOLD FORMAT
+
+The format of thresholds specified in --warning and --critical arguments
+is defined at <http://nagiosplug.sourceforge.net/developer-guidelines.html#THRESHOLDFORMAT>.
+
+For example to be crtical if more than 100 messages, more than 90 messages_ready,
+more than 20 messages_unacknowledged or no fewer than 10 consumers use
+
+--critical=100,90,20,10:
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_queue -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_OVERVIEW OK - messages OK (25794) messages_ready OK (22971)
+      messages_unacknowledged OK (2823) consumers OK (10) | messages=25794;;
+      messages_ready=22971;; messages_unacknowledged=2823;; consumers=10;;
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_server
+++ b/files/nrpe/check_rabbitmq_server
@@ -1,0 +1,358 @@
+#!/usr/bin/env perl
+
+###  check_rabbitmq_aliveness.pl
+
+# Use the management overview to check server statistics
+
+##############################################################################
+# prologue
+use strict;
+use warnings;
+
+use Monitoring::Plugin qw(OK CRITICAL WARNING UNKNOWN);
+use Monitoring::Plugin::Functions qw(%STATUS_TEXT);
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use Data::Dumper;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout $code $message);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management node API to check server process parameters.',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+$p->add_arg(spec => 'node|n=s',
+    help => "Specify the node name (default is hostname)"
+);
+
+$p->add_arg(
+    spec => 'warning|w=s',
+
+    help =>
+qq{-w, --warning=INTEGER,INTEGER,INTEGER,INTEGER
+   Warning thresholds specified in order that the metrics are returned.
+   (Default : %s)},
+#   required => 1,
+   default => "80,80,80,80",
+);
+
+$p->add_arg(
+    spec => 'critical|c=s',
+    help =>
+qq{-c, --critical=INTEGER,INTEGER,INTEGER,INTEGER
+   Warning thresholds specified in order that the metrics are returned.
+   (Default: %s) },
+   default => "90,90,90,90",
+);
+
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(spec => 'rname|r=s',
+    help => "RabbitName (default: %s)",
+    default => "rabbit",
+);
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# Check we have four values for warning and critical thresholds
+my @warning = split(',', $p->opts->warning);
+$p->nagios_die("You should specify four ranges for --warning argument") unless $#warning == 3;
+
+my @critical = split(',', $p->opts->critical);
+$p->nagios_die("You should specify four ranges for --critical argument") unless $#critical == 3;
+
+##############################################################################
+# check stuff.
+
+my $hostname = $p->opts->hostname;
+
+my $nodename = $p->opts->node;
+
+my $rname = $p->opts->rname;
+
+if (!$nodename) {
+    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $nodename = $1;
+}
+
+my $port = $p->opts->port;
+
+my $path = "nodes/$rname\@$nodename";
+
+my $url = sprintf("http%s://%s:%d/api/%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $path);
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
+my $res = $ua->request($req);
+
+if (!$res->is_success) {
+    # Deal with standard error conditions - make the messages more sensible
+    if ($res->code == 400) {
+        my $bodyref = decode_json $res->content;
+        $p->nagios_exit(CRITICAL, $bodyref->{'reason'});
+    }
+    $res->code == 404 and $p->nagios_die("Not found: ".$path);
+    $res->code == 401 and $p->nagios_die("Access refused: ".$path);
+    if ($res->code < 200 or $res->code > 400 ) {
+        $p->nagios_exit(CRITICAL, "Received ".$res->status_line." for path: ".$path);
+    }
+}
+
+my $bodyref = decode_json $res->content;
+
+if (!$bodyref->{'running'}) {
+    $p->nagios_exit(CRITICAL, "Not running: ".$path);
+}
+
+check($p, "Memory", $bodyref->{'mem_used'}, $bodyref->{'mem_limit'}, $warning[0], $critical[0]);
+check($p, "Process", $bodyref->{'proc_used'}, $bodyref->{'proc_total'}, $warning[1], $critical[1]);
+check($p, "FD", $bodyref->{'fd_used'}, $bodyref->{'fd_total'}, $warning[2], $critical[2]);
+check($p, "Sockets", $bodyref->{'sockets_used'}, $bodyref->{'sockets_total'}, $warning[3], $critical[3]);
+
+($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit( return_code=>$code, message=>$message);
+
+
+sub check {
+    my $p = shift;
+    my $label = shift;
+    my $used = shift;
+    my $limit = shift;
+    my $warning = shift;
+    my $critical = shift;
+
+    if (!$p || !defined($used)) {
+      $p->nagios_exit( return_code=>CRITICAL, message=>'Unable to get values for '.$label);
+    } else {
+      my $value = percent($used, $limit);
+      my $code = $p->check_threshold(check => $value, warning => $warning, critical => $critical);
+      $p->add_message($code, sprintf("$label ".$STATUS_TEXT{$code}." (%.2f%%)", $value)) ;
+      $p->add_perfdata(label=>$label, value => $value, uom=>"%", warning=>$warning, critical=>$critical);
+    }
+}
+
+sub percent {
+    my $num = shift;
+    my $denom = shift;
+    $num = 0 if $num eq "unknown";
+    my $value = ($num/ $denom)*100;
+    return sprintf("%.2f", $value)
+}
+
+sub structured {
+    my $content = shift;
+    $Data::Dumper::Terse = 1;          # don't output names where feasible
+    $Data::Dumper::Indent = 2;
+    return Dumper($content);
+}
+
+=head1 NAME
+
+check_rabbitmq_server - Nagios plugin using RabbitMQ management API to
+check the server resource usage (processes, memory, file descriptors, and sock descriptors)
+
+=head1 SYNOPSIS
+
+check_rabbitmq_server [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check the resource usage of the
+server.  This check looks at the node statistics for the rabbit node on
+the host and examines the erlang memory, process and file descriptor usage.
+
+It provides performance data for each of these variables and allows for
+warning and criticality levels to be specified for each.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item -w | --warning
+
+The warning levels, expressed as a percentage for each of memory, process,
+file descriptor and sockets usage.  This field consists of four comma-separated
+integers.  (default: 80,80,80,80)
+
+=item -c | --critical
+
+The critical levels, expressed as a percentage for each of memory, process,
+file descriptor and sockets usage.  This field consists of four comma-separated
+integers.  (default: 90,90,90,90)
+
+=item -n | --node
+
+The node name (default is hostname)
+
+=item -r | --rname
+
+The rabbit name (default is rabbit)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_server -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_SERVER OK - Memory OK (6.19%) Process OK (0.01%)
+        FD OK (2.53%) Sockets OK (0.86%) | Memory=6.19%;80;90 Process=0.01%;80;90 FD=2.53%;80;90 Sockets=0.86%;1;2
+
+You can specify different warning and criticality levels.  B<-w> and B<-c>
+both accept four comma-separated percentages which represent the
+thresholds for memory, process and file descriptor usage respectively.  For
+example, to specify warnings for memory at 60%, process at 80%, file
+descriptors at 95%, and socket descriptors at 90%:
+
+    check_rabbitmq_server -H rabbit.example.com  -w 60,80,95,90
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;

--- a/files/nrpe/check_rabbitmq_shovels
+++ b/files/nrpe/check_rabbitmq_shovels
@@ -1,0 +1,261 @@
+#!/usr/bin/perl -w
+use strict;
+use warnings;
+use JSON -support_by_pp;
+use LWP::UserAgent;
+use Monitoring::Plugin;
+
+
+$::PROGRAM = "check_rabbitmq_shovels";
+$::VERSION = "1.0";
+
+
+#
+# main
+#
+MAIN: {
+    run() unless caller();
+}
+
+
+#
+# run()
+# ---
+sub run {
+    my $np = Monitoring::Plugin->new(
+        plugin  => $::PROGRAM,
+        version => $::VERSION,
+        blurb   => "check that all the shovels of the given RabbitMQ host "
+                 . "are running",
+        usage   => "Usage: %s [-H host]",
+        timeout => 5,
+    );
+
+    # declare options
+    $np->add_arg(
+        spec    => "hostname|host|H=s",
+        help    => "Specify the RabbitMQ host to query. Defaults to '%s'.",
+        default => "localhost",
+    );
+    $np->add_arg(
+        spec    => "port|P=s",
+        help    => "Specify the port number to query RabbitMQ on. Defaults to %s.",
+        default => 15672,
+    );
+    $np->add_arg(
+        spec    => "username|user|u=s",
+        help    => "Specify the username. Defaults to '%s'.",
+        default => "guest",
+    );
+    $np->add_arg(
+        spec    => "password|pass|p=s",
+        help    => "Specify the password. Defaults to '%s'.",
+        default => "guest",
+    );
+
+    # parse options
+    $np->getopts;
+
+    # --------------------------------------
+
+    # create and configure the JSON parser
+    my $json = JSON->new;
+    $json->allow_nonref->utf8->relaxed->escape_slash->loose;
+    $json->allow_singlequote->allow_barekey;
+
+    # construct the URL authority
+    my $url_authority = $np->opts->username . ":" . $np->opts->password
+                      . '@' . $np->opts->hostname . ":" . $np->opts->port;
+
+    # fetch the list of shovels
+    alarm $np->opts->timeout;
+    my $agent       = LWP::UserAgent->new;
+    my $response    = $agent->get("http://$url_authority/api/shovels");
+
+    $np->nagios_exit(
+        return_code => CRITICAL,
+        message     => "API error: ".$response->status_line
+        ) unless $response->is_success;
+
+    # decode the JSON
+    my $shovels = eval { $json->decode($response->decoded_content || "[]") };
+
+    $np->nagios_exit(
+        return_code => CRITICAL,
+        message     => "API error: could not parse JSON: $@"
+        ) if $@;
+
+    $np->nagios_exit(
+        return_code => CRITICAL,
+        message     => "API error: empty JSON"
+        ) unless @$shovels;
+
+    # process the shovels
+    my (@running, @blocked, @terminated);
+
+    for my $shovel (@$shovels) {
+        push @running, $shovel->{name} and next
+            if $shovel->{state} eq "running";
+        push @blocked, $shovel->{name} and next
+            if $shovel->{state} eq "blocked";
+        push @terminated, $shovel->{name} and next
+            if $shovel->{state} eq "terminated";
+    }
+
+    # construct the status message
+    my ($status, @message);
+
+    if (@running) {
+        my $s = (my $n = @running) > 1 ? "s" : "";
+        unshift @message, "$n running shovel$s: @running";
+        $status = OK;
+    }
+    if (@blocked) {
+        my $s = (my $n = @blocked) > 1 ? "s" : "";
+        unshift @message, "$n blocked shovel$s: @blocked";
+        $status = WARNING;
+    }
+    if (@terminated) {
+        my $s = (my $n = @terminated) > 1 ? "s" : "";
+        unshift @message, "$n terminated shovel$s: @terminated";
+        $status = CRITICAL;
+    }
+
+    # return the appropriate status code and message
+    $np->nagios_exit(
+        return_code => $status,
+        message     => join ", ", @message,
+    );
+}
+
+
+1
+
+__END__
+
+=pod
+
+=head1 NAME
+
+check_rabbitmq_shovels - Nagios plugin to check that all shovels of the
+given RabbitMQ host are running
+
+
+=head1 SYNOPSIS
+
+    check_rabbitmq_shovels --hostname <host>
+    check_rabbitmq_shovels { --help | --man | --version }
+
+
+=head1 OPTIONS
+
+=head2 Program options
+
+=over
+
+=item B<-H>, B<--hostname> I<string>
+
+Specify the RabbitMQ host to query. Defaults to C<localhost>.
+
+=item B<-P>, B<--port> I<number>
+
+Specify the port number to query RabbitMQ on. Defaults to 15672.
+
+=item B<-u>, B<--user>, B<--username> I<string>
+
+Specify the username. Defaults to C<guest>.
+
+=item B<-p>, B<--pass>, B<--password> I<string>
+
+Specify the password. Defaults to C<guest>.
+
+=item B<-t>, B<--timeout> I<duration>
+
+Specify the timeout period in seconds. Defaults to 5.
+
+=back
+
+=head2 Help options
+
+=over
+
+=item B<-?>, B<--usage>
+
+Print a short usage description, then exit.
+
+=item B<-h>, B<--help>
+
+Print a more detailed help screen, then exit.
+
+=item B<-V>, B<--version>
+
+Print the program name and version, then exit.
+
+=back
+
+
+=head1 DESCRIPTION
+
+This program is a Nagios plugin that uses the JSON over HTTP API 
+to check that all shovels of the given RabbitMQ host are running.
+The default settings match the standard installation of RabbitMQ.
+
+The check returns C<OK> if all shovels are running, C<WARNING> if
+one or more shovels are blocked, C<CRITICAL> if one or more shovels
+are terminated.
+
+
+=head1 EXAMPLES
+
+With default settings, only the hostname need to be specified:
+
+    check_rabbitmq_shovels -H <host>
+
+It prints the global status and the details of the shovels, by
+decreasing order or criticity:
+
+    RABBITMQ_SHOVELS OK - 3 running shovels: klonk zlott swish
+
+    RABBITMQ_SHOVELS WARNING - 1 blocked shovel: klonk, 2 running shovels: zlott swish
+
+    RABBITMQ_SHOVELS CRITICAL - 1 terminated shovel: zlott, 1 blocked shovel: klonk, 1 running shovel: swish
+
+In the case of an API error, the program will give an appropriate
+diagnostic:
+
+    RABBITMQ_SHOVELS CRITICAL - API error: 401 Unauthorized
+
+    RABBITMQ_SHOVELS CRITICAL - API error: 500 Can't connect to <host>:<port>
+
+    RABBITMQ_SHOVELS CRITICAL - API error: could not parse JSON: malformed JSON string
+
+    RABBITMQ_SHOVELS CRITICAL - API error: empty JSON
+
+
+=head1 SEE ALSO
+
+See L<Monitoring::Plugin>
+
+The RabbitMQ management plugin is described at
+L<http://www.rabbitmq.com/management.html>
+
+
+=head1 LICENSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+=head1 AUTHOR
+
+Sebastien Aperghis-Tramoni (sebastien@aperghis.net)
+

--- a/files/nrpe/check_rabbitmq_watermark
+++ b/files/nrpe/check_rabbitmq_watermark
@@ -1,0 +1,287 @@
+#!/usr/bin/env perl
+
+###  check_rabbitmq_watermark.pl
+
+# Use the management API to check if mem_alarm or disk_free_alarm has been triggered.
+
+# Originally by Nathan Vonnahme, n8v at users dot sourceforge
+# dot net, July 19 2006
+
+##############################################################################
+# prologue
+use strict;
+use warnings;
+
+use Monitoring::Plugin;
+use LWP::UserAgent;
+use URI::Escape;
+use JSON;
+
+use vars qw($VERSION $PROGNAME  $verbose $timeout);
+$VERSION = '2.0.3';
+
+# get the base name of this script for use in the examples
+use File::Basename;
+$PROGNAME = basename($0);
+
+
+##############################################################################
+# define and get the command line options.
+#   see the command line option guidelines at
+#   http://nagiosplug.sourceforge.net/developer-guidelines.html#PLUGOPTIONS
+
+
+# Instantiate Monitoring::Plugin object (the 'usage' parameter is mandatory)
+my $p = Monitoring::Plugin->new(
+    usage => "Usage: %s [options] -H hostname",
+    license => "",
+    version => $VERSION,
+    blurb => 'This plugin uses the RabbitMQ management API to check if the mem_alarm or disk_free_alarm has been triggered',
+);
+
+$p->add_arg(spec => 'hostname|host|H=s',
+    help => "Specify the host to connect to",
+    required => 1
+);
+$p->add_arg(spec => 'port=i',
+    help => "Specify the port to connect to (default: %s)",
+    default => 15672
+);
+$p->add_arg(spec => 'node|n=s',
+    help => "Specify the node name (default is hostname)"
+);
+$p->add_arg(spec => 'username|user|u=s',
+    help => "Username (default: %s)",
+    default => "guest",
+);
+$p->add_arg(spec => 'password|p=s',
+    help => "Password (default: %s)",
+    default => "guest"
+);
+
+$p->add_arg(spec => 'vhost=s',
+    help => "Specify the vhost to test (default: %s)",
+    default => "/"
+);
+
+$p->add_arg(spec => 'ssl|ssl!',
+    help => "Use SSL (default: false)",
+    default => 0
+);
+
+$p->add_arg(spec => 'ssl_strict|ssl_strict!',
+    help => "Verify SSL certificate (default: true)",
+    default => 1
+);
+
+$p->add_arg(spec => 'proxy|proxy!',
+    help => "Use environment proxy (default: true)",
+    default => 1
+);
+$p->add_arg(spec => 'proxyurl=s',
+    help => "Use proxy url like http://proxy.domain.com:8080",
+);
+
+$p->add_arg(spec => 'rname|r=s',
+    help => "RabbitName (default: %s)",
+    default => "rabbit",
+);
+
+
+# Parse arguments and process standard ones (e.g. usage, help, version)
+$p->getopts;
+
+
+# perform sanity checking on command line options
+
+
+##############################################################################
+# check stuff.
+
+my $hostname=$p->opts->hostname;
+my $port=$p->opts->port;
+my $vhost=uri_escape($p->opts->vhost);
+
+my $nodename = $p->opts->node;
+
+my $rname = $p->opts->rname;
+
+if (!$nodename) {
+    $hostname =~ /^([a-zA-Z0-9-]*)/;
+    $nodename = $1;
+}
+
+my $url = sprintf("http%s://%s:%d/api/nodes/%s\@%s", ($p->opts->ssl ? "s" : ""), $hostname, $port, $rname, $nodename);
+
+my $ua = LWP::UserAgent->new;
+if (defined $p->opts->proxyurl)
+{
+    $ua->proxy('http', $p->opts->proxyurl);
+}
+elsif($p->opts->proxy == 1 )
+{
+    $ua->env_proxy;
+}
+$ua->agent($PROGNAME.' ');
+$ua->timeout($p->opts->timeout);
+if ($p->opts->ssl and $ua->can('ssl_opts')) {
+    $ua->ssl_opts(verify_hostname => $p->opts->ssl_strict);
+}
+my $req = HTTP::Request->new(GET => $url);
+$req->authorization_basic($p->opts->username, $p->opts->password);
+my $res = $ua->request($req);
+
+if (!$res->is_success) {
+    # Deal with standard error conditions - make the messages more sensible
+    if ($res->code == 400) {
+        my $bodyref = decode_json $res->content;
+        $p->nagios_exit(CRITICAL, $bodyref->{'reason'});
+    }
+    $res->code == 404 and $p->nagios_die("Not found");
+    $res->code == 401 and $p->nagios_die("Access refused");
+    if ($res->code < 200 or $res->code > 400 ) {
+        $p->nagios_exit(CRITICAL, "Received ".$res->status_line);
+    }
+}
+
+my $bodyref = decode_json $res->content;
+my @checks = ("mem_alarm", "disk_free_alarm");
+
+for my $check (@checks) {
+    if ($bodyref->{$check} eq 0) {
+        $p->add_message(OK, "$check");
+    } else {
+        $p->add_message(CRITICAL, "$check");
+    }
+}
+
+my($code, $message) = $p->check_messages(join_all=>', ');
+$p->nagios_exit(
+    return_code => $code,
+    message => $message
+);
+
+=head1 NAME
+
+check_rabbitmq_watermark - Nagios plugin using RabbitMQ management API to check if the mem_alarm or disk_free_alarm has been triggered
+
+=head1 SYNOPSIS
+
+check_rabbitmq_watermark [options] -H hostname
+
+=head1 DESCRIPTION
+
+Use the management interface of RabbitMQ to check if the mem_alarm or disk_free_alarm has been triggered.
+
+It uses Monitoring::Plugin and accepts all standard Nagios options.
+
+=head1 OPTIONS
+
+=over
+
+=item -h | --help
+
+Display help text
+
+=item -v | --verbose
+
+Verbose output
+
+=item -t | --timeout
+
+Set a timeout for the check in seconds
+
+=item -H | --hostname | --host
+
+The host to connect to
+
+=item --port
+
+The port to connect to (default: 15672)
+
+=item --ssl
+
+Use SSL when connecting (default: false)
+
+=item --vhost
+
+The vhost to create the test queue within (default: /)
+
+=item -n | --node
+
+The node name (default is hostname)
+
+=item -r | --rname
+
+The rabbit name (default is rabbit)
+
+=item --username | --user
+
+The user to connect as (default: guest)
+
+=item -p | --password
+
+The password for the user (default: guest)
+
+=back
+
+=head1 EXAMPLES
+
+The defaults all work with a standard fresh install of RabbitMQ, and all that
+is needed is to specify the host to connect to:
+
+    check_rabbitmq_watermark -H rabbit.example.com
+
+This returns a standard Nagios result:
+
+    RABBITMQ_ALIVENESS OK - vhost: /
+
+You can choose a different vhost to use for the check also:
+
+    check_rabbitmq_watermark -H rabbit.example.com --vhost /foo
+
+=head1 ERRORS
+
+The check tries to provide useful error messages on the status line for
+standard error conditions.
+
+Otherwise it returns the HTTP Error message returned by the management
+interface.
+
+=head1 EXIT STATUS
+
+Returns zero if check is OK otherwise returns standard Nagios exit codes to
+signify WARNING, UNKNOWN or CRITICAL state.
+
+=head1 SEE ALSO
+
+See Monitoring::Plugin(3)
+
+The RabbitMQ management plugin is described at
+http://www.rabbitmq.com/management.html
+
+=head1 LICENSE
+
+This file is part of nagios-plugins-rabbitmq.
+
+Copyright 2010, Platform 14.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 AUTHOR
+
+James Casey <jamesc.000@gmail.com>
+
+=cut
+
+1;


### PR DESCRIPTION
Add monitoring scripts for RabbitMQ. The scripts are from here:
https://github.com/nagios-plugins-rabbitmq/nagios-plugins-rabbitmq

These are written in Perl, so the user of these scripts will need to
install some Perl dependencies. On CentOS, these would be (via yum):

 - perl-URI
 - perl-JSON
 - perl-LWP-UserAgent-Determined
 - perl-Monitoring-Plugin

Installing those will obviously also pull in Perl if it is not already
installed. Installation is left to the module user - the scripts are
added here only for distribution purposes.