### PR TITLE
Check now supports multiple ranges of VLANs

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -609,8 +609,12 @@ class OSCapacityCheck():
 
     # The 'network_vlan_ranges' parameter looks like: 'default:80:89'
     # the 2nd number is the lower vlan id, the 3rd is the higher id
-    vlan_range = config['network_vlan_ranges'].split(':')
-    vlans_total = int(vlan_range[2]) - int(vlan_range[1])
+    # It can also look like 'default:80:89,default:65:75' so we loop over it.
+    vlan_ranges = config['network_vlan_ranges'].split(',')
+    vlans_total = 0
+    for vrange in vlan_ranges:
+      vlan_range = vrange.split(':')
+      vlans_total = int(vlans_total) + (int(vlan_range[2]) - int(vlan_range[1]))
 
     return { 'vlans_used': vlans_in_use, 'vlans_total': vlans_total }
 


### PR DESCRIPTION
Tested on devel together with pouta-puppet/CCCP-1837 and the check_openstack capacity no longer breaks because the changed network_vlan_ranges variable.

 - #CCCP-1837