### PR TITLE
only count networks that have a segmentation_id

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -591,7 +591,11 @@ class OSCapacityCheck():
 
   def check_vlan_capacity(self):
     nets = self.neutron.list_networks()['networks']
-    vlans_in_use = len(nets)
+    vlans_in_use = 0
+    for net in nets:
+      # There are networks without segmentation_id
+      if net['provider:segmentation_id']:
+        vlans_in_use = vlans_in_use + 1
 
     # Need to find how many are available
 


### PR DESCRIPTION
as using a vlan. The public network used for floating IP addresses does
not have a segmentation id.

There are probably ways to do this with fewer lines. Maybe lambda() or filter() or some other function that I don't know about.