### PR TITLE
Cccp 300.2

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -898,7 +898,7 @@ class OSKeystoneAvailability():
     self.keystone = keystoneclientv3.Client(session=sessionx)
 
   def get_keystone(self):
-    vols = self.keystone.project.list()
+    vols = self.keystone.projects.list()
 
   def execute(self):
     results = dict()


### PR DESCRIPTION
Make the API performance test faster for keystone and user, this will make it easier to spot variations in the graphs.