### PR TITLE
Floating IPs with project_name

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -675,7 +675,7 @@ class OSCapacityCheck():
 
     SERVICE_TENANT_NAME="service"
     PUBLIC_NET_NAME="public"
-    public_network_id = self.neutron.list_networks(tenant_id=SERVICE_TENANT_NAME,
+    public_network_id = self.neutron.list_networks(project_name=SERVICE_TENANT_NAME,
                          name=PUBLIC_NET_NAME)['networks'][0]['id']
 
     # Our public IP's are used for routers in addition to instances so we must


### PR DESCRIPTION
For some reason ePouta does not have this problem. Tested the change there. I don't know why this is happening.

Error:
<pre>
File "/usr/local/nagios/libexec/nrpe_local/check_openstack.py", line 679, in check_floating_ips
    name=PUBLIC_NET_NAME)['networks'][0]['id']
IndexError: list index out of range
</pre>

According to pip list:
 - On an API node in devel we currently have neutron 9.4.1 and python-neutronclient 6.0.1.
 - On an API node in test we currently have neutron 9.3.1 and python-neutronclient 6.0.0.

Testing:
--------

Running the capacity check before this PR (so with tenant_id="service" to neutron.list_networks) from devel towards:
 - itself, then it fails with the error above.
 - test, it succeeds
 - prod, it succeeds

Running capacity check after this PR (so with project_name="service" to neutron.list_networks and newer version of most packages) from devel towards:
 - itself, it succeeds
 - test, it succeeds
 - prod, it succeeds

Running the capacity check before this PR (so with tenant_id="service" to neutron.list_networks and older version of neutron and python-neutronclient) from test towards:
 - itself, it succeeds
 - devel, it fails
 - prod, it succeeds

Running the capacity check after this PR (so with project_name="service" to neutron.list_networks and older version of neutron and python-neutronclient) from test towards:
 - itself, it succeeds
 - test, it succeeds,
 - prod, it succeeds