### PR TITLE
Switch to project_id instead of name

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -675,7 +675,7 @@ class OSCapacityCheck():
 
     SERVICE_TENANT_NAME="service"
     PUBLIC_NET_NAME="public"
-    public_network_id = self.neutron.list_networks(project_name=SERVICE_TENANT_NAME,
+    public_network_id = self.neutron.list_networks(project_id=SERVICE_TENANT_NAME,
                          name=PUBLIC_NET_NAME)['networks'][0]['id']
 
     # Our public IP's are used for routers in addition to instances so we must


### PR DESCRIPTION
It seems we changed code from tenant_id to project_name. tenant_id was
deprecated in favor of project_id. Project_name is a different
functioning value so seems an error. This has been tested in prod
manually and resolves the floating ip issue.

Ref:
https://github.com/openstack/python-neutronclient/blob/master/neutronclient/v2_0/client.py