### PR TITLE
Updated variable name for flavor count

### DIFF
--- a/files/nrpe/check_openstack_usage_stats.py
+++ b/files/nrpe/check_openstack_usage_stats.py
@@ -86,7 +86,7 @@ def get_per_flavor_active_vm_count(nova):
        name = nova.flavors.get(flavor)
      except NovaNotFound:
        continue
-     flavor_name_dict["num_vms_" + str(name.name).replace(".", '_')] = flavor_id_dict[flavor]
+     flavor_name_dict["num_vms_by_flavors." + str(name.name).replace(".", '_')] = flavor_id_dict[flavor]
   return flavor_name_dict
 
 


### PR DESCRIPTION
The previous commit the nagios check name overlapped with another variables which would have made it hard to use wildcard. This fixes that issue.