### PR TITLE
ExaBGP checks

### DIFF
--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -57,7 +57,7 @@ if [ "x" == "x$LOG_FILE_NAME" ]; then
 fi
 
 RETURN_METRICS=""
-MED_STATUSES_RAW=$(tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
+MED_STATUSES_RAW=$(/bin/tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
                                                                                                                   #^^^^^^^^^^ more opportunism
 if [ -z "${MED_STATUSES_RAW// }" ]; then
   echo "Did not get any data when trying to read ${LOG_FILE_NAME}."

--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -66,16 +66,16 @@ fi
 # fi
 
 LATEST_MED_STATUS=$(tail -${TAIL_LINES} ${LOG_FILE_NAME} | perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -1)
-SERVICE_IP=echo "$LATEST_MED_STATUS" | awk '{print $1}'
-MED_VALUE=echo "$LATEST_MED_STATUS" | awk '{print $2}'
-COMMUNITY_VALUE=echo "$LATEST_MED_STATUS" | awk '{print $3}'
+SERVICE_IP=$(echo "$LATEST_MED_STATUS" | awk '{print $1}')
+MED_VALUE=$(echo "$LATEST_MED_STATUS" | awk '{print $2}')
+#COMMUNITY_VALUE=echo "$LATEST_MED_STATUS" | awk '{print $3}'
 
-if [ -z "${SERVICE_IP}"]; then
+if [ -z "${SERVICE_IP}" ]; then
   echo "No Service IP information found!"
   exit ${STATE_CRITICAL}
 fi
 
-if [ -z "${MED_VALUE}"]; then
+if [ -z "${MED_VALUE}" ]; then
   echo "No MED information found!"
   exit ${STATE_CRITICAL}
 fi

--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Check with which Multi-Exit Discriminator value each Service IP is announced
+# from ExaBGP, based on a log file.
+
+set -e
+
+STATE_OK=0
+STATE_WARNING=1
+STATE_CRITICAL=2
+STATE_UNKNOWN=3
+
+TAIL_LINES=1000
+
+usage ()
+{
+    echo "Usage: $0 [OPTIONS]"
+    echo " -h               Get help"
+    echo " -f               Log file to inspect"
+    echo " -a <address>     Address whose MED to check"
+}
+
+if (($# == 0)); then
+  usage
+  exit 1
+fi
+
+while getopts ':f:a:h' OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+        f)
+            LOG_FILE_NAME=$OPTARG
+            ;;
+        a)
+            CHECK_ADDRESS=$OPTARG
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+        :)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ "x" == "x$LOG_FILE_NAME" ]; then
+  echo "option -f is required"
+  exit ${STATE_WARNING}
+fi
+
+if [ "x" == "x$MULTI_ADDRESS" ]; then
+  echo "option -a is required"
+  exit ${STATE_WARNING}
+fi
+
+LAST_MED_STATUS=$(tail -${TAIL_LINES} /var/log/messages | perl -n -e'/(${CHECK_ADDRESS})\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -1)
+MED_VALUE=echo "$LAST_MED_STATUS" | awk '{print $1}'
+COMMUNITY_VALUE=echo "$LAST_MED_STATUS" | awk '{print $2}'
+
+#echo "OK | med=${MED_VALUE};; community=${COMMUNITY_VALUE}"
+echo "OK | med=${MED_VALUE};;"
+exit ${STATE_OK}

--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Check with which Multi-Exit Discriminator value each Service IP is announced
+# Check with which Multi-Exit Discriminator value Service IPs are announced
 # from ExaBGP, based on a log file.
 
 set -e
@@ -10,6 +10,7 @@ STATE_WARNING=1
 STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
+# Opportunism.
 TAIL_LINES=1000
 
 usage ()
@@ -17,7 +18,7 @@ usage ()
     echo "Usage: $0 [OPTIONS]"
     echo " -h               Get help"
     echo " -f               Log file to inspect"
-    echo " -a <address>     Address whose MED to check"
+    # echo " -a <address>     Address whose MED to check"
 }
 
 if (($# == 0)); then
@@ -35,9 +36,9 @@ do
         f)
             LOG_FILE_NAME=$OPTARG
             ;;
-        a)
-            CHECK_ADDRESS=$OPTARG
-            ;;
+        # a)
+        #     CHECK_ADDRESS=$OPTARG
+        #     ;;
         \?)
             usage
             exit 1
@@ -59,15 +60,26 @@ if [ "x" == "x$LOG_FILE_NAME" ]; then
   exit ${STATE_WARNING}
 fi
 
-if [ "x" == "x$MULTI_ADDRESS" ]; then
-  echo "option -a is required"
-  exit ${STATE_WARNING}
+# if [ "x" == "x$MULTI_ADDRESS" ]; then
+#   echo "option -a is required"
+#   exit ${STATE_WARNING}
+# fi
+
+LATEST_MED_STATUS=$(tail -${TAIL_LINES} ${LOG_FILE_NAME} | perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -1)
+SERVICE_IP=echo "$LATEST_MED_STATUS" | awk '{print $1}'
+MED_VALUE=echo "$LATEST_MED_STATUS" | awk '{print $2}'
+COMMUNITY_VALUE=echo "$LATEST_MED_STATUS" | awk '{print $3}'
+
+if [ -z "${SERVICE_IP}"]; then
+  echo "No Service IP information found!"
+  exit ${STATE_CRITICAL}
 fi
 
-LAST_MED_STATUS=$(tail -${TAIL_LINES} /var/log/messages | perl -n -e'/(${CHECK_ADDRESS})\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -1)
-MED_VALUE=echo "$LAST_MED_STATUS" | awk '{print $1}'
-COMMUNITY_VALUE=echo "$LAST_MED_STATUS" | awk '{print $2}'
+if [ -z "${MED_VALUE}"]; then
+  echo "No MED information found!"
+  exit ${STATE_CRITICAL}
+fi
 
-#echo "OK | med=${MED_VALUE};; community=${COMMUNITY_VALUE}"
-echo "OK | med=${MED_VALUE};;"
+#echo "OK | ${SERVICE_IP}_MED=${MED_VALUE};; ${SERVICE_IP}_CTY=${COMMUNITY_VALUE};;"
+echo "OK | ${SERVICE_IP}_MED=${MED_VALUE};;"
 exit ${STATE_OK}

--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -18,7 +18,6 @@ usage ()
     echo "Usage: $0 [OPTIONS]"
     echo " -h               Get help"
     echo " -f               Log file to inspect"
-    # echo " -a <address>     Address whose MED to check"
 }
 
 if (($# == 0)); then
@@ -36,9 +35,6 @@ do
         f)
             LOG_FILE_NAME=$OPTARG
             ;;
-        # a)
-        #     CHECK_ADDRESS=$OPTARG
-        #     ;;
         \?)
             usage
             exit 1
@@ -60,11 +56,6 @@ if [ "x" == "x$LOG_FILE_NAME" ]; then
   exit ${STATE_WARNING}
 fi
 
-# if [ "x" == "x$MULTI_ADDRESS" ]; then
-#   echo "option -a is required"
-#   exit ${STATE_WARNING}
-# fi
-
 RETURN_METRICS=""
 MED_STATUSES_RAW=$(tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
                                                                                                                   #^^^^^^^^^^ more opportunism
@@ -80,7 +71,8 @@ if [ ! -z "${MED_STATUSES_RAW}" ]; then
       echo "No MED information found!"
       exit ${STATE_WARNING}
     fi
-    RETURN_METRICS+="${SERVICE_IP}_MED=${MED_VALUE} "
+    SERVICE_IP_NODOTS="$(echo ${SERVICE_IP}|sed 's/\./_/g')"
+    RETURN_METRICS+="${SERVICE_IP_NODOTS}_MED=${MED_VALUE} "
   done <<< "$MED_STATUSES_RAW"
 fi
 

--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -57,7 +57,7 @@ if [ "x" == "x$LOG_FILE_NAME" ]; then
 fi
 
 RETURN_METRICS=""
-MED_STATUSES_RAW=$(/bin/tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
+MED_STATUSES_RAW=$(sudo /bin/tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
                                                                                                                   #^^^^^^^^^^ more opportunism
 if [ -z "${MED_STATUSES_RAW// }" ]; then
   echo "Did not get any data when trying to read ${LOG_FILE_NAME}."

--- a/files/nrpe/check_interface_addresses.sh
+++ b/files/nrpe/check_interface_addresses.sh
@@ -79,5 +79,5 @@ for IF_CHECK_ADDR in "${MULTI_ADDRESS[@]}"; do
   fi
 done
 
-echo "OK"
+echo "OK | rc=${STATE_OK}"
 exit ${STATE_OK}

--- a/files/nrpe/check_interface_addresses.sh
+++ b/files/nrpe/check_interface_addresses.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Check that given interface is UP and has given address.
+
+#set -e
+
+STATE_OK=0
+STATE_WARNING=1
+STATE_CRITICAL=2
+STATE_UNKNOWN=3
+
+usage ()
+{
+    echo "Usage: $0 [OPTIONS]"
+    echo " -h               Get help"
+    echo " -i <interface>   Interface to inspect"
+    echo " -a <address>     Address whose presence to check. Can be repeated."
+}
+
+if (($# == 0)); then
+  usage
+  exit 1
+fi
+
+while getopts ':i:a:h' OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+        i)
+            IF_NAME=$OPTARG
+            ;;
+        a)
+            MULTI_ADDRESS+=("$OPTARG")
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+        :)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+if [ "x" == "x$IF_NAME" ]; then
+  echo "option -i is required"
+  exit
+fi
+
+if [ "x" == "x$MULTI_ADDRESS" ]; then
+  echo "option -a is required"
+  exit
+fi
+
+IF_HAS_UP=$(ip -4 -o link show ${IF_NAME}|grep -Po "<.*,UP,.*>")
+if [ $? -ne 0 ]; then
+  echo "Interface ${IF_NAME} is not up."
+  exit ${STATE_CRITICAL}
+else
+  echo "Interface ${IF_NAME} is up."
+fi
+
+for IF_CHECK_ADDR in "${MULTI_ADDRESS[@]}"; do
+  IF_HAS_IP=$(ip -4 -o addr show "${IF_NAME}"|grep -Po "${IF_CHECK_ADDR}")
+  if [ $? -ne 0 ]; then
+    echo "Address ${IF_CHECK_ADDR} missing from interface ${IF_NAME}."
+    exit ${STATE_WARNING}
+  else
+    echo "Address ${IF_CHECK_ADDR} present on interface ${IF_NAME}."
+  fi
+done
+
+exit ${STATE_OK}

--- a/files/nrpe/check_interface_addresses.sh
+++ b/files/nrpe/check_interface_addresses.sh
@@ -53,12 +53,12 @@ shift "$((OPTIND-1))"
 
 if [ "x" == "x$IF_NAME" ]; then
   echo "option -i is required"
-  exit
+  exit ${STATE_WARNING}
 fi
 
 if [ "x" == "x$MULTI_ADDRESS" ]; then
   echo "option -a is required"
-  exit
+  exit ${STATE_WARNING}
 fi
 
 IF_HAS_UP=$(ip -4 -o link show ${IF_NAME}|grep -Po "<.*,UP,.*>")
@@ -79,4 +79,5 @@ for IF_CHECK_ADDR in "${MULTI_ADDRESS[@]}"; do
   fi
 done
 
+echo "OK"
 exit ${STATE_OK}


### PR DESCRIPTION
Add two checks:

- `check_exabgp_med_announce.sh` monitors the announced med level of each Service IP
- `check_interface_addresses.sh` monitors that dummy IPs carry proper Service IPs.
