### PR TITLE
print check_megaraid disk errors as performance data

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/CSCfi/puppet-opsviewagent.svg?token=KEpY44314kezBxxvLxTR&branch=master)](https://travis-ci.com/CSCfi/puppet-opsviewagent)
+[![Build Status](https://travis-ci.org/CSCfi/puppet-opsviewagent.svg?branch=master)](https://travis-ci.org/CSCfi/puppet-opsviewagent)
 
 opsviewagent
 ============
@@ -16,4 +16,4 @@ Contact
 Support
 -------
 
-Please log tickets and issues at our [Projects site](http://projects.example.com)
+Please log tickets and issues here on Github

--- a/files/nrpe/check_megaraid
+++ b/files/nrpe/check_megaraid
@@ -28,7 +28,8 @@
 # Code for correct RAID level reporting contributed by Frode Nordahl, 2009/01/12.
 #
 # $Author: delgado $
-# $Revision: #12 $ $Date: 2010/10/18 $
+# $Revision: #13 $ $Date: 2018/03/14 $
+# Modified 2018/03/14 by jguldmyr to print errorcount as performancedata
 
 use strict;
 use Getopt::Std;
@@ -241,6 +242,8 @@ if ( $hotspares ) {
 		$result .= "Hotspare(s):$hotsparecount";
 	}
 }
+
+$result .= "| errors=$errorcount";
 
 exitreport($status, $result);
 


### PR DESCRIPTION
Before this change:

<pre>
# /usr/local/nagios/libexec/nrpe_local/check_megaraid 
OK: 0:0:RAID-0:6 drives:2.179TB:Optimal Drives:6 
</pre>

After this change

<pre>
# /usr/local/nagios/libexec/nrpe_local/check_megaraid 
OK: 0:0:RAID-0:6 drives:2.179TB:Optimal Drives:6 | errors=0
</pre>

Tested manually on a node in prod with errors and on a devel node.