### PR TITLE
Store the 3MB file in the user's homedirectory

### DIFF
--- a/files/nrpe/check_object.py
+++ b/files/nrpe/check_object.py
@@ -282,10 +282,12 @@ class S3FunctionalityTest():
     """ store a 3MB object in the bucket
     """
 
-    if not os.path.exists("3MBFILE"):
-      with open("3MBFILE", "wb") as out:
+    USERHOMEDIR = os.path.expanduser('~')
+    TESTFILEPATH = "%s/3MBFILE" % USERHOMEDIR
+    if not os.path.exists(TESTFILEPATH):
+      with open(TESTFILEPATH, "wb") as out:
           out.truncate(1024 * 1024 * 3)
-    self.k.set_contents_from_filename("3MBFILE")
+    self.k.set_contents_from_filename(TESTFILEPATH)
 
   def s3_read_data(self):
     """ read object from bucket


### PR DESCRIPTION
Without this it tries to store the file in / or wherever the script runs from.

Tested on one of the devel nodes by first deleting $HOME/3MBFILE and calling the check from the monitoring server.