### PR TITLE
Ensure opsview-agent absent when installing nrpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is the opsviewagent module.
 
 It no longer works great with opsview-agent (especially the nrpe.cfg has some now nrpe hard coded paths).
 
+To resolve conflicts between the packages when changing from opsview-agent to nrpe then before nrpe is installed the role will ensure opsview-agent is absent.
+
 License
 -------
 

--- a/files/nrpe/check_megaraid
+++ b/files/nrpe/check_megaraid
@@ -30,10 +30,11 @@
 # $Author: delgado $
 # $Revision: #13 $ $Date: 2018/03/14 $
 # Modified 2018/03/14 by jguldmyr to print errorcount as performancedata
+# Modified 2018/06/11 by jguldmyr to find utils.pm in nrpe installdir instead of opsview
 
 use strict;
 use Getopt::Std;
-use lib "/usr/local/nagios/libexec";
+use lib "/usr/lib64/nagios/plugins";
 use utils qw(%ERRORS);
 
 our($opt_h, $opt_s, $opt_o, $opt_m, $opt_p);


### PR DESCRIPTION
 - Before installing nrpe we make sure ospview-agent is absent
 - Needed to rename Package for installing the daemon to prevent double
   declarations.
- Make check_megaraid work with nrpe by making it look for perl modules
   where the nagios-plugins-perl rpm installs them: /usr/lib64/nagios/plugins

This has been tested on io1. 

 - #CCCP-2033