### PR TITLE
Create opsview style directories

### DIFF
--- a/manifests/nrpe_command.pp
+++ b/manifests/nrpe_command.pp
@@ -3,7 +3,7 @@ define opsviewagent::nrpe_command(
   $script_arguments,
   $use_sudo = false,
 ) {
-  File[$name] ~> Service['opsview-agent']
+  File[$name] ~> Service['nrpe-daemon-service']
 
   # script is defined with absolute path
   if $script_name =~ /^\/.*/ {

--- a/manifests/nrpe_script.pp
+++ b/manifests/nrpe_script.pp
@@ -1,7 +1,7 @@
 define opsviewagent::nrpe_script(
   $script_source,
 ) {
-  File[$name] ~> Service['opsview-agent']
+  File[$name] ~> Service['nrpe-daemon-service']
 
   file { $name:
     path    => "${opsviewagent::nrpe_local_script_path}/${name}",


### PR DESCRIPTION
Our custom checks needs to be somewhere and I prefer to have them in any other
directory than the one where rpms install checks.

<pre>
Error: Cannot create /usr/local/nagios/libexec/nrpe_local; parent directory /usr/local/
Error: /Stage[main]/Opsviewagent/File[nrpe-scripts]/ensure: change from absent to direclocal/nagios/libexec does not exist
</pre>

Tested on compute (fresh install) and an api and a backend node.

 - #CCCP-2033