### PR TITLE
Catch and pass SSHException

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -401,6 +401,10 @@ class OSGhostInstanceCheck():
         logging.warn('unable to connect to {0}'.format(host))
         logging.warn('{0}: {1}'.format(e.__class__.__name__, e))
         raise HostNotAvailableException(host=host)
+      except paramiko.SSHException as e:
+        logging.warn('SSHException when connecting to {0}'.format(host))
+        logging.warn('{0}: {1}'.format(e.__class__.__name__, e))
+        pass
 
     return instances
 


### PR DESCRIPTION
If a node is under high load it accepts a TCP connection to the
SSH server but never properly responds. This eventually results
in a paramiko.SSHException being raised. No point to give up on
checking on other hosts due to this, so capture exception, log
and then pass.