### PR TITLE
Hunt for PCI Ghosts

### DIFF
--- a/files/nrpe/check_pci_ghosts.sh
+++ b/files/nrpe/check_pci_ghosts.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Hunts for PCI devices ghosts á la nagios
+#
+# Ghosts show up in Newton OpenStack if one does a rebuild.
+#  https://bugs.launchpad.net/nova/+bug/1780441
+#
+# Use case: GPUs and pci_passthrough
+# Requirements:
+#  - An SQL user with access to these databases.tables: 
+#   - nova.pci_devices, nova.instances, nova_api.flavor_extra_specs
+
+# Written by Johan Guldmyr @ CSC 2018
+
+## Nagios return codes
+WARNING=1
+CRITICAL=2
+UNKNOWN=3
+OK=0
+
+SQLPATH="/usr/local/nagios/libexec/nrpe_local/find_pci_ghosts.sql"
+
+if [ ! -f $SQLPATH ]; then
+  echo "UNKNOWN: cannot find $SQLPATH"
+  exit $UNKNOWN
+fi
+
+HUNTGHOSTS="$(mysql --skip-column-names < $SQLPATH)"
+# replace newlines with spaces
+LISTGHOSTS="$(echo "$HUNTGHOSTS"|tr "\n" " ")"
+# -n and grep -c to make this work also when there are no ghosts
+COUNTGHOSTS="$(echo -n "$HUNTGHOSTS"|grep -c '^')"
+
+if [ x"$HUNTGHOSTS" != x ]; then
+  echo "CRITICAL: we found $COUNTGHOSTS instance(s) with _wrong_ amount of PCI devices: $LISTGHOSTS | ghosts=$COUNTGHOSTS"
+  exit $CRITICAL
+else
+  echo "OK: All instances with PCI devices have same amount of PCI devices as their flavor specifies | ghosts=$COUNTGHOSTS"
+  exit $OK
+fi

--- a/files/nrpe/find_pci_ghosts.sql
+++ b/files/nrpe/find_pci_ghosts.sql
@@ -1,0 +1,24 @@
+# Prints instances from nova.pci_devices table that have a different amount of pci devices than their flavors
+# Assumes that column value for flavors with pci_aliases are colon separated like M10:1 or P100:4
+SELECT my_uuids
+FROM
+(
+  SELECT 
+    pcid.instance_uuid as my_uuids,
+    count(pcid.instance_uuid) as actual_gpus,
+    SUBSTRING_INDEX(flex.value, ':', -1) as flavor_gpus
+  FROM 
+    nova.pci_devices pcid, 
+    nova.instances inst,
+    nova_api.flavor_extra_specs flex
+  WHERE 
+    pcid.status = "allocated" AND 
+    inst.uuid = pcid.instance_uuid AND
+    inst.instance_type_id = flex.flavor_id AND
+    flex.`key` LIKE "%alias"
+  GROUP BY 
+    pcid.instance_uuid
+  HAVING 
+    actual_gpus != flavor_gpus
+) 
+AS T


### PR DESCRIPTION
SQL file to run an SQL query that lists the UUIDs of instances which
have the _wrong_ amount of GPUs vs what their flavor says they should
have.

Can happen sometimes when one does a rebuild.

https://bugs.launchpad.net/nova/+bug/1780441

 - #CCCP-2234