### PR TITLE
Override nrpe package unitfile with templated unitfile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,7 +204,7 @@ class opsviewagent (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('puppet-opsviewagent/nrpe.service.erb'),
+    content => template('opsviewagent/nrpe.service.erb'),
   }
 
   exec { "systemctl daemon-reload on nrpe unitfile change}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@ class opsviewagent (
   }
 
   file { 'nrpe-unitfile':
-    ensure  => true,
+    ensure  => file,
     path    => '/usr/lib/systemd/system/nrpe.service',
     owner   => 'root',
     group   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,14 +200,14 @@ class opsviewagent (
 
   file { 'nrpe-unitfile':
     ensure  => true,
-    path    => "/usr/lib/systemd/system/nrpe.service",
+    path    => '/usr/lib/systemd/system/nrpe.service',
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => template('opsviewagent/nrpe.service.erb'),
   }
 
-  exec { "systemctl daemon-reload on nrpe unitfile change}":
+  exec { 'systemctl daemon-reload on nrpe unitfile change':
     command     => 'systemctl daemon-reload',
     refreshonly => true,
     logoutput   => on_failure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class opsviewagent (
   User[$nagios_user] -> Package['nrpe-daemon']
   File['opsview-nagios-dir'] -> File['opsview-libexec-dir']
   File['opsview-libexec-dir'] -> File['nrpe-scripts']
+  File['nrpe-unitfile'] ~> Service['nrpe-daemon-service']
   File['nrpe-scripts'] ~> Service['nrpe-daemon-service']
   File['nrpe-configs'] ~> Service['nrpe-daemon-service']
   File['nrpe.cfg'] ~> Service['nrpe-daemon-service']
@@ -195,6 +196,23 @@ class opsviewagent (
     mode    => '0550',
     owner   => $nagios_user,
     group   => $nagios_user,
+  }
+
+  file { 'nrpe-unitfile':
+    ensure  => true,
+    path    => "/usr/lib/systemd/system/nrpe.service",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('puppet-opsviewagent/nrpe.service.erb'),
+  }
+
+  exec { "systemctl daemon-reload on nrpe unitfile change}":
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    logoutput   => on_failure,
+    subscribe   => File['nrpe-unitfile'],
+    notify      => Service['nrpe-daemon-service'],
   }
 
 }

--- a/templates/nrpe.service.erb
+++ b/templates/nrpe.service.erb
@@ -9,7 +9,7 @@ WantedBy=multi-user.target
 
 [Service]
 Type=forking
-User=nrpe
-Group=nrpe
+User=<%= @nagios_user %>
+Group=<%= @nagios_user %>
 EnvironmentFile=/etc/sysconfig/nrpe
 ExecStart=/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -d $NRPE_SSL_OPT

--- a/templates/nrpe.service.erb
+++ b/templates/nrpe.service.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=Nagios Remote Program Executor
+Documentation=http://www.nagios.org/documentation
+Conflicts=nrpe.socket
+Requires=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=forking
+User=nrpe
+Group=nrpe
+EnvironmentFile=/etc/sysconfig/nrpe
+ExecStart=/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -d $NRPE_SSL_OPT


### PR DESCRIPTION
Before starting nrpe service, install custom systemd unitfile based on template. Service should also refresh if/when template changes.