### PR TITLE
check_load alert levels now depend on # of cores  

### DIFF
--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -131,7 +131,7 @@ allow_weak_random_seed=0
 # Opsview checks
 command[check_users]=/usr/lib64/nagios/plugins/check_users $ARG1$
 # Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
-command[check_load]=/usr/lib64/nagios/plugins/check_load -a '-w <%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + Integer(@processorcount.to_i/10) %>'
+command[check_load]=/usr/lib64/nagios/plugins/check_load -w <%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>
 command[check_disk]=/usr/lib64/nagios/plugins/check_disk $ARG1$
 command[check_swap]=/usr/lib64/nagios/plugins/check_swap $ARG1$
 command[check_procs]=/usr/lib64/nagios/plugins/check_procs $ARG1$

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -131,7 +131,8 @@ allow_weak_random_seed=0
 # Opsview checks
 command[check_users]=/usr/lib64/nagios/plugins/check_users $ARG1$
 # Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
-command[check_load]=/usr/lib64/nagios/plugins/check_load -w <%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>
+# resulting in this for a 1 core system: -w 4,3,2 -c 7,5,3
+command[check_load]=/usr/lib64/nagios/plugins/check_load -w <%= @processorcount.to_i + 3 %>,<%= @processorcount.to_i + 2 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + 6 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 4 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>
 command[check_disk]=/usr/lib64/nagios/plugins/check_disk $ARG1$
 command[check_swap]=/usr/lib64/nagios/plugins/check_swap $ARG1$
 command[check_procs]=/usr/lib64/nagios/plugins/check_procs $ARG1$

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -130,7 +130,8 @@ allow_weak_random_seed=0
 
 # Opsview checks
 command[check_users]=/usr/lib64/nagios/plugins/check_users $ARG1$
-command[check_load]=/usr/lib64/nagios/plugins/check_load $ARG1$
+# Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
+command[check_load]=/usr/lib64/nagios/plugins/check_load -a '-w <%= @processorcount + 1 %>,<%= @processorcount + 1 %>,<%= @processorcount + 1 %>-c <%=@processorcount + Integer(@processorcount/10) %>,<%= @processorcount + Integer(@processorcount/10) %>,<%= @processorcount + Integer(@processorcount/10) %>'
 command[check_disk]=/usr/lib64/nagios/plugins/check_disk $ARG1$
 command[check_swap]=/usr/lib64/nagios/plugins/check_swap $ARG1$
 command[check_procs]=/usr/lib64/nagios/plugins/check_procs $ARG1$

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -131,7 +131,7 @@ allow_weak_random_seed=0
 # Opsview checks
 command[check_users]=/usr/lib64/nagios/plugins/check_users $ARG1$
 # Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
-command[check_load]=/usr/lib64/nagios/plugins/check_load -a '-w <%= @processorcount + 1 %>,<%= @processorcount + 1 %>,<%= @processorcount + 1 %>-c <%=@processorcount + Integer(@processorcount/10) %>,<%= @processorcount + Integer(@processorcount/10) %>,<%= @processorcount + Integer(@processorcount/10) %>'
+command[check_load]=/usr/lib64/nagios/plugins/check_load -a '-w <%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + Integer(@processorcount.to_i/10) %>'
 command[check_disk]=/usr/lib64/nagios/plugins/check_disk $ARG1$
 command[check_swap]=/usr/lib64/nagios/plugins/check_swap $ARG1$
 command[check_procs]=/usr/lib64/nagios/plugins/check_procs $ARG1$


### PR DESCRIPTION
 - #CCCP-2587

So a node with 1 core get:
<pre>
-command[check_load]=/usr/lib64/nagios/plugins/check_load $ARG1$
+# Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
+# resulting in this for a 1 core system: -w 4,3,2 -c 7,5,3
+command[check_load]=/usr/lib64/nagios/plugins/check_load -w 4,3,2 -c 7,5,3
</pre>

A node with 32 cores gets:

<pre>
-w 35,34,33 -c 41,39,37
</pre>

Because we no longer allow $ARG1$ the NRPE daemon for check "check_load" will throw away all arguments that might be supplied by the monitoring system and instead it will use the hard coded ones. This is considered by some a security improvement.