### PR TITLE
Revert "check_load alert levels now depend on # of cores   (#48)"

### DIFF
--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -130,9 +130,7 @@ allow_weak_random_seed=0
 
 # Opsview checks
 command[check_users]=/usr/lib64/nagios/plugins/check_users $ARG1$
-# Hard code check_load to give warning at # of cores+1 and critical at # of cores + cores/10)
-# resulting in this for a 1 core system: -w 4,3,2 -c 7,5,3
-command[check_load]=/usr/lib64/nagios/plugins/check_load -w <%= @processorcount.to_i + 3 %>,<%= @processorcount.to_i + 2 %>,<%= @processorcount.to_i + 1 %> -c <%=@processorcount.to_i + 6 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 4 + Integer(@processorcount.to_i/10) %>,<%= @processorcount.to_i + 2 + Integer(@processorcount.to_i/10) %>
+command[check_load]=/usr/lib64/nagios/plugins/check_load $ARG1$
 command[check_disk]=/usr/lib64/nagios/plugins/check_disk $ARG1$
 command[check_swap]=/usr/lib64/nagios/plugins/check_swap $ARG1$
 command[check_procs]=/usr/lib64/nagios/plugins/check_procs $ARG1$


### PR DESCRIPTION
This reverts commit d0cba270f1388de4c095ba8489f5b52cd5133891.