### PR TITLE
Add smaller capcity checks to check_openstack.py

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -810,7 +810,6 @@ class OSCapacityCheckCPUs(OSCapacityCheck):
     try:
       results.update(self.check_host_aggregate_capacities())
       resultsx = dict((key, value) for (key, value) in results.iteritems() if '_cpus_' in key and 'aggr_' in key)
-      print resultsx
     except:
       raise
     return resultsx

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -783,7 +783,7 @@ class OSCapacityCheck():
     return results
 
 
-class OSCapacityCheckSimple(OSCapacityCheck):
+class OSCapacityCheckNetwork(OSCapacityCheck):
   def execute(self):
     results = dict()
     try:
@@ -1113,7 +1113,7 @@ def execute_check(options, args):
     'neutron': OSNeutronAvailability,
     'nova': OSNovaAvailability,
     'keystone': OSKeystoneAvailability,
-    'capacitysimple': OSCapacityCheckSimple,
+    'capacitysimple': OSCapacityCheckNetwork,
     'capacitycpus': OSCapacityCheckCPUs,
     'capacityram': OSCapacityCheckRAM,
   }

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -782,6 +782,39 @@ class OSCapacityCheck():
       raise
     return results
 
+
+class OSCapacityCheckSimple(OSCapacityCheck):
+  def execute(self):
+    results = dict()
+    try:
+      results.update(self.check_vlan_capacity())
+      if self.options.no_ping == False:
+        results.update(self.check_floating_ips())
+    except:
+      raise
+    return results
+
+class OSCapacityCheckRAM(OSCapacityCheck):
+  def execute(self):
+    results = dict()
+    try:
+      results.update(self.check_host_aggregate_capacities())
+      resultsx =dict((key, value) for (key, value) in results.iteritems() if '_mem_' in key and 'aggr_' in key)
+    except:
+      raise
+    return resultsx
+
+class OSCapacityCheckCPUs(OSCapacityCheck):
+  def execute(self):
+    results = dict()
+    try:
+      results.update(self.check_host_aggregate_capacities())
+      resultsx = dict((key, value) for (key, value) in results.iteritems() if '_cpus_' in key and 'aggr_' in key)
+      print resultsx
+    except:
+      raise
+    return resultsx
+
 class OSBarbicanAvailability():
   '''
   Check Barbicam API call length by using list
@@ -1081,6 +1114,9 @@ def execute_check(options, args):
     'neutron': OSNeutronAvailability,
     'nova': OSNovaAvailability,
     'keystone': OSKeystoneAvailability,
+    'capacitysimple': OSCapacityCheckSimple,
+    'capacitycpus': OSCapacityCheckCPUs,
+    'capacityram': OSCapacityCheckRAM,
   }
 
 

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -1113,7 +1113,7 @@ def execute_check(options, args):
     'neutron': OSNeutronAvailability,
     'nova': OSNovaAvailability,
     'keystone': OSKeystoneAvailability,
-    'capacitysimple': OSCapacityCheckNetwork,
+    'capacitynetwork': OSCapacityCheckNetwork,
     'capacitycpus': OSCapacityCheckCPUs,
     'capacityram': OSCapacityCheckRAM,
   }


### PR DESCRIPTION
This tries to fix an issue where our 'capacity' check returns a too
long string to our loging.

This would make it possible to have different aggregate checks for
cpus, ram, and other. The only adds three checks that return same
but less data as the 'capacity' check. The following checks are:

capacityram, capacitycpus, capacitysimple

CCCP-2753