### PR TITLE
Enhance aggregate splitting logic

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -756,9 +756,10 @@ class OSCapacityCheck():
     enabled_hypervisors = filter(lambda x: x.service['host'] in enabled_hosts, hypervisors)
 
     for aggr in host_aggregates:
-      # If a skylake aggregate and we have not specified "only skylake" then we skip it
+      # If not a skylake aggregate and we have specified "only skylake" then we skip it
       if "skylake" not in aggr.name and self.options.only_skylake == True:
         continue
+      # If a skylake aggregate and we have not specified "only skylake" then we skip it
       if "skylake" in aggr.name and self.options.only_skylake == False:
         continue
       aggr_hypervisors = filter(lambda hv: hv.hypervisor_hostname in aggr.hosts, enabled_hypervisors)

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -50,7 +50,7 @@ DEFAULT_MAX_WAIT_TIME    = 90
 DEFAULT_PING_COUNT       = 5
 DEFAULT_PING_INTERVAL    = 2
 DEFAULT_NO_PING          = False
-DEFAULT_ONLY_WINDOWS     = False
+DEFAULT_ONLY_SKYLAKE     = False
 
 STATUS_VOLUME_AVAILABLE  = 'available'
 STATUS_VOLUME_OK_DELETE  = ['available', 'error']
@@ -756,8 +756,11 @@ class OSCapacityCheck():
     enabled_hypervisors = filter(lambda x: x.service['host'] in enabled_hosts, hypervisors)
 
     for aggr in host_aggregates:
-      # If a windows aggregate and we have not specified "only windows" then we skip it
-      if "windows" in aggr.name and self.options.only_windows == False: continue
+      # If a skylake aggregate and we have not specified "only skylake" then we skip it
+      if "skylake" not in aggr.name and self.options.only_skylake == True:
+        continue
+      if "skylake" in aggr.name and self.options.only_skylake == False:
+        continue
       aggr_hypervisors = filter(lambda hv: hv.hypervisor_hostname in aggr.hosts, enabled_hypervisors)
 
       total_aggr_cpus = sum(map(lambda hv: hv.vcpus, aggr_hypervisors))
@@ -1023,7 +1026,7 @@ def parse_command_line():
   parser.add_option("-w", "--wait", dest='wait', type='int', help='max seconds to wait for creation')
   parser.add_option("-z", "--no-ping", dest='no_ping', action='store_true', help='no ping test')
   parser.add_option("-j", "--milliseconds", dest='milliseconds', action='store_true', help='Show time in milliseconds')
-  parser.add_option("-k", "--only-windows", dest='only_windows', action='store_true', help='Option to only print windows aggregate OSCapacity as a way to combat 1024 character limit in check_nrpe')
+  parser.add_option("-k", "--only-skylake", dest='only_skylake', action='store_true', help='Option to only print skylake aggregate OSCapacity as a way to combat 1024 character limit in check_nrpe')
   
   (options, args) = parser.parse_args()
 
@@ -1052,8 +1055,8 @@ def parse_command_line():
   if options.milliseconds:
     global USE_SECONDS
     USE_SECONDS = False
-  if not options.only_windows:
-    options.only_windows = DEFAULT_ONLY_WINDOWS
+  if not options.only_skylake:
+    options.only_skylake = DEFAULT_ONLY_SKYLAKE
 
   if len(args) == 0:
     sys.exit(NAGIOS_STATE_UNKNOWN, 'Command argument missing! Use --help.')


### PR DESCRIPTION
Instead of the logic:

"if x and only_x"

...handle both cases:

"if not x and only_x"
"if x and not only_x"

...which should make the split work more optimally.

Also, instead of 'windows', do the filtering based on 'skylake',
which should bucket things nicely to two <1024char result sets.