### PR TITLE
Fixed check_nrpe regex bug

### DIFF
--- a/files/nrpe/check_crm
+++ b/files/nrpe/check_crm
@@ -20,6 +20,9 @@
 #		    threshold ( Zoran Bosnjak & Marko Hrastovec )
 # v0.8 01/09/2019 - Use sudo to run crm commands ( Johan Guldmyr )
 #
+# v.0.9 22/07/2019 - Add fix for unmanaged resources as the regex didn't  match
+#                   when you are using FQDN ( dots / hyphens)
+#
 # NOTES: Requires Perl 5.8 or higher & the Perl Module Nagios::Plugin
 
 use warnings;
@@ -183,7 +186,7 @@ sub check_failed_actions {
 
 sub check_unmanaged_resources {
   my $line = shift;
-  if ( $line =~ m/\s*(\S+?)\s+\(.*\)\:\s+\w+\s+\w+\s+\(unmanaged\)\s+/i )
+  if ( $line =~ m/\s*(\S+?)\s+\(.*\)\:\s+\w+\s+\S+\s+\(unmanaged\)\s+/i )
   {
       $np->add_message( CRITICAL, "; resource $1 unmanaged" );
   }


### PR DESCRIPTION
The current version of the check_nrpe check unmanaged(maintenance mode)
verification check was not working as the regex was matching for
alphanumeric strings where the hostname was in crm status output.
Because of the use of FQDN with dots and hyphens it caused the regex to
fail.

Switching from \w+  (a-z, A-Z, 0-9, _) ( + being one or more )
to \S+   (any non-white space character) ( + being one or more )

meant that the full hostname was captured by the regex as intended.