### PR TITLE
bugfix for CCCP-2969

### DIFF
--- a/files/nrpe/check_exabgp_med_announce.sh
+++ b/files/nrpe/check_exabgp_med_announce.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Check with which Multi-Exit Discriminator value Service IPs are announced
-# from ExaBGP, based on a log file.
+# from ExaBGP, based on systemd service journal.
 
 set -e
 
@@ -10,62 +10,39 @@ STATE_WARNING=1
 STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
-# Opportunism
-TAIL_LINES=1000
+SERVICE_NAME=exabgp.service
 
 usage ()
 {
     echo "Usage: $0 [OPTIONS]"
     echo " -h               Get help"
-    echo " -f               Log file to inspect (legacy placeholder"
-    echo " -s               systemctl service (defaults to  exabgp.service)"
+    echo " -s               systemctl service (defaults to exabgp.service)"
 }
 
-if (($# == 0)); then
-  usage
-  exit 1
-fi
-
-while getopts ':f:a:h:s:' OPTION
+while getopts 'hs:' OPTION
 do
     case $OPTION in
         h)
             usage
-            exit 0
-            ;;
-        f)
-            LOG_FILE_NAME=${OPTARG}
+            exit ${STATE_WARNING}
             ;;
         s)
             SERVICE_NAME=${OPTARG}
             ;;
         \?)
             usage
-            exit 1
+            exit ${STATE_WARNING}
             ;;
         *)
             usage
-            exit 1
-            ;;
-        :)
-            usage
-            exit 1
+            exit ${STATE_WARNING}
             ;;
     esac
 done
 shift "$((OPTIND-1))"
 
-if [ "x" == "x$LOG_FILE_NAME" ]; then
-  echo "option -f is required"
-  exit ${STATE_WARNING}
-fi
-if [  -z "$SERVICE_NAME" ]; then
-SERVICE_NAME=exabgp.service
-fi
-
 RETURN_METRICS=""
-#MED_STATUSES_RAW=$(sudo journalctl -e  --unit ${SERVICE_NAME} /bin/tail -${TAIL_LINES} ${LOG_FILE_NAME}| perl -n -e'/(\S+)\/32.*med\s(\d+)\s/ && print "$1 $2\n"' | tail -10 | sort | uniq)
-MED_STATUSES_RAW=$(sudo journalctl -e -n10  --unit  ${SERVICE_NAME} | awk '/.*announce route/{print $15" "$17 }'|sort -u)
+MED_STATUSES_RAW=$(sudo journalctl -e -n10 --unit ${SERVICE_NAME} | awk '/.*announce route/{print $15" "$17 }'|sort -u)
 if [ -z "${MED_STATUSES_RAW// }" ]; then
   echo "Did not get any data when trying to read ${LOG_FILE_NAME}."
   exit ${STATE_CRITICAL}


### PR DESCRIPTION
journalctl -e -n10  --unit  ${SERVICE_NAME}
prints last 10 service checks from defined unit.
This obsoletes -f /var/log/messages  tailing and perl check