### PR TITLE
Horizon login and load time checks

### DIFF
--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Check if Horizon login works externally (from internet, outside of haproxy)
+# Check if Horizon login works externally (outside of haproxy)
 
 STATE_OK=0
 STATE_WARNING=1

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -56,8 +56,8 @@ done
 shift "$((OPTIND-1))"
 
 CURL="/bin/curl"
-COOKIE_FILE=~/horizontestcookie
-CSV_FILE=~/horizonresultfile
+COOKIE_FILE=$(/usr/bin/mktemp)
+CSV_FILE=$(/usr/bin/mktemp)
 DATE_START=$(date '+%Y-%m-%d')
 DATE_END=$DATE_START
 # Mandatory.
@@ -107,5 +107,5 @@ else
   exit ${STATE_OK}
 fi
 
-rm $COOKIE_FILE
-rm $CSV_FILE
+rm -f $COOKIE_FILE
+rm -f $CSV_FILE

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -18,6 +18,7 @@ usage ()
     echo " -R <URL>         Region URL (Keystone endpoint)"
     echo " -H <host>        Base host part for curl call URLs"
     echo " -I <project_id>  Project ID"
+    echo " -T <seconds>     Timeout"
 }
 
 if (($# == 0)); then
@@ -47,6 +48,9 @@ do
         I)
             export HZ_TEST_PROJECT_ID=$OPTARG
             ;;
+        T)
+            export MAX_TIME=$OPTARG
+            ;;
 	*)
             usage
             exit ${STATE_UNKNOWN}
@@ -56,6 +60,7 @@ done
 shift "$((OPTIND-1))"
 
 CURL="/bin/curl"
+MAX_TIME=60
 COOKIE_FILE=$(/usr/bin/mktemp)
 CSV_FILE=$(/usr/bin/mktemp)
 DATE_START=$(date '+%Y-%m-%d')
@@ -72,12 +77,12 @@ HORIZON_PROJECT_ID="$HZ_TEST_PROJECT_ID"
 LOGIN_START=$(date +%s.%6N)
 
 # Retrieve a CSRF token into the cookie file.
-$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
 TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
 
 # Sign in. Note! A bit confusingly, the region must be the keystone endpoint.
 DATA="username=$HORIZON_USER&password=$HORIZON_PASSWORD&region=$HORIZON_REGION&csrfmiddlewaretoken=$TOKEN"
-$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s -d "$DATA" --referer "$HORIZON_HOST/dashboard/" "$HORIZON_HOST/dashboard/auth/login/"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s -d "$DATA" --referer "$HORIZON_HOST/dashboard/" "$HORIZON_HOST/dashboard/auth/login/"
 
 # Check that we actually got a proper login session.
 SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
@@ -88,11 +93,11 @@ fi
 
 # Switch project context if interested in some particular project.
 TENANT_URL="$HORIZON_HOST/dashboard/auth/switch/$HORIZON_PROJECT_ID/?next=/dashboard/project/"
-$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$TENANT_URL"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s "$TENANT_URL"
 
 # Get a usage report.
 URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
-$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE -s "$URL"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE --max-time $MAX_TIME -s "$URL"
 RETURNCODE=$?
 
 # Halt timer, see how long it took.

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -84,6 +84,6 @@ if [ "${RETURNCODE}" -ne 0 ]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "
   exit ${STATE_CRITICAL}
 else
-  echo "OK: ${IPTABLES_NEUTRON_STATUS} | TODO_LOGIN_TIMER "
+  echo "OK: Login to Horizon was successful | " # TODO_LOGIN_TIMER
   exit ${STATE_OK}
 fi

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -96,11 +96,13 @@ LOGIN_START=$(date +%s.%6N)
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
 TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
 
-# Sign in. Note! A bit confusingly, the region must be the keystone endpoint.
+# Sign in. Note! The region must match the endpoint defined in AVAILABLE_REGIONS in Horizon's local_settings config.
 DATA="username=$HORIZON_USER&password=$HORIZON_PASSWORD&region=$HORIZON_REGION&csrfmiddlewaretoken=$TOKEN"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s -d "$DATA" --referer "$HORIZON_HOST/dashboard/" "$HORIZON_HOST/dashboard/auth/login/"
 
-# Check that we actually got a proper login session.
+# Check that we got a session. Note! This proves only that Django successfully created a session
+# after a POST was done with the correct CSRF token. It does not prove that the login worked.
+# If the login failed, Django still creates a session; it just considers it anonymous.
 SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
 if [ "$SESSIONID" == "" ]; then
   echo "CRIT: Session ID not present on file $COOKIE_FILE |"
@@ -112,9 +114,12 @@ fi
 TENANT_URL="$HORIZON_HOST/dashboard/auth/switch/$HORIZON_PROJECT_ID/?next=/dashboard/project/"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME -s "$TENANT_URL"
 
-# Get a usage report.
+# Get a usage report and see that it contains expected content.
+# This is the actual proof that the login worked end-to-end.
+# Another approach would be to interpret curl output if you're keen on parsing XML.
 URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE --max-time $MAX_TIME -s "$URL"
+grep 'Usage Report' $CSV_FILE
 RETURNCODE=$?
 
 # Halt timer, see how long it took.
@@ -122,6 +127,7 @@ LOGIN_END=$(date +%s.%6N)
 LOGIN_TIME=$(echo "${LOGIN_END} - ${LOGIN_START}" | bc -l)
 LOGIN_TIME_INT=$(echo "${LOGIN_TIME}"|awk -F'.' '{print $1}')
 
+# Remove cookie and result files
 cleanup
 
 if [[ "${RETURNCODE}" -ne 0 ]]; then

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -57,37 +57,45 @@ shift "$((OPTIND-1))"
 
 CURL="/bin/curl"
 COOKIE_FILE=~/horizontestcookie
+CSV_FILE=~/horizonresultfile
+DATE_START=$(date '+%Y-%m-%d')
+DATE_END=$DATE_START
+# Mandatory.
 HORIZON_USER="$HZ_TEST_USERNAME"
 HORIZON_PASSWORD="$HZ_TEST_PASSWORD"
 HORIZON_REGION="$HZ_TEST_REGION"
 HORIZON_HOST="$HZ_TEST_HOST"
-# If project ID is omitted, the check result will be based on whichever project Horizon picks for the user.
+# Optional. If project ID is omitted, the check result will be based on whichever project Horizon picks for the user.
 HORIZON_PROJECT_ID="$HZ_TEST_PROJECT_ID"
-CSV_FILE=~/horizonresultfile
-DATE_START=$(date '+%Y-%m-%d')
-DATE_END=$DATE_START
 
+# Start timer.
 LOGIN_START=$(date +%s.%6N)
 
+# Retrieve a CSRF token into the cookie file.
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
 TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
 
+# Sign in. Note! A bit confusingly, the region must be the keystone endpoint.
 DATA="username=$HORIZON_USER&password=$HORIZON_PASSWORD&region=$HORIZON_REGION&csrfmiddlewaretoken=$TOKEN"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s -d "$DATA" --referer "$HORIZON_HOST/dashboard/" "$HORIZON_HOST/dashboard/auth/login/"
 
+# Check that we actually got a proper login session.
 SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
 if [ "$SESSIONID" == "" ]; then
     echo "Error: sessionid not present on file $COOKIE_FILE"
     exit 1
 fi
 
+# Switch project context if interested in some particular project.
 TENANT_URL="$HORIZON_HOST/dashboard/auth/switch/$HORIZON_PROJECT_ID/?next=/dashboard/project/"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$TENANT_URL"
 
+# Get a usage report.
 URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE -s "$URL"
 RETURNCODE=$?
 
+# Halt timer, see how long it took.
 LOGIN_END=$(date +%s.%6N)
 LOGIN_TIME=$( echo "${LOGIN_END} - ${LOGIN_START}" | bc -l )
 

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Check if Horizon login works externally (from internet, outside of haproxy)
+
+STATE_OK=0
+STATE_WARNING=1
+STATE_CRITICAL=2
+STATE_UNKNOWN=3
+
+usage ()
+{
+    echo "Usage: $0 [OPTIONS]"
+    echo " -h               Get help"
+    echo " -U <username>    Username to use for Horizon login"
+    echo " -P <password>    Password to use for Horizon login"
+    echo " -R <URL>         Region URL"
+    echo " -H <hostname>    Hostname"
+    echo " -I <project_id>  Project ID"
+}
+
+while getopts 'h:H:U:T:P:' OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+        U)
+            export HZ_TEST_USERNAME=$OPTARG
+            ;;
+        P)
+            export HZ_TEST_PASSWORD=$OPTARG
+            ;;
+        R)
+            export HZ_TEST_REGION=$OPTARG
+            ;;
+        H)
+            export HZ_TEST_HOST=$OPTARG
+            ;;
+        I)
+            export HZ_TEST_PROJECT_ID=$OPTARG
+            ;;
+	*)
+            usage
+            exit ${STATE_UNKNOWN}
+            ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+
+CURL="/bin/curl"
+COOKIE_FILE="~/horizontestcookie"
+HORIZON_USER="$HZ_TEST_USERNAME"
+HORIZON_PASSWORD="$HZ_TEST_PASSWORD"
+HORIZON_REGION="$HZ_TEST_REGION"
+HORIZON_HOST="$HZ_TEST_HOST"
+HORIZON_PROJECT_ID="$HZ_TEST_PROJECT_ID"
+CSV_FILE="~/horizonresultfile"
+DATE_START=$(date '+%Y-%m-%d')
+DATE_END=$DATE_START
+
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
+TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
+
+DATA="username=$HORIZON_USER&password=$HORIZON_PASSWORD&region=$HORIZON_REGION&csrfmiddlewaretoken=$TOKEN"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s -d "$DATA" --referer "$HORIZON_HOST/dashboard/" "$HORIZON_HOST/dashboard/auth/login/"
+
+SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
+if [ "$SESSIONID" == "" ]; then
+    echo "Error: sessionid not present on file $COOKIE_FILE"
+    exit 1
+fi
+
+TENANT_URL="$HORIZON_HOST/dashboard/auth/switch/$HORIZON_PROJECT_ID/?next=/dashboard/project/"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$TENANT_URL"
+
+URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
+$CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE -s "$URL"
+
+RETURNCODE=$?
+
+if [ "${RETURNCODE}" -ne 0 ]; then
+  echo "CRIT: Unable to login to Horizon and perform actions | "
+  exit ${STATE_CRITICAL}
+else
+  echo "OK: ${IPTABLES_NEUTRON_STATUS} | TODO_LOGIN_TIMER "
+  exit ${STATE_OK}
+fi

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -16,14 +16,20 @@ CRIT=45
 
 usage ()
 {
-    echo "Usage: $0 [OPTIONS]"
-    echo " -h               Get help"
-    echo " -U <username>    Username to use for Horizon login"
-    echo " -P <password>    Password to use for Horizon login"
-    echo " -R <URL>         Region URL (Keystone endpoint)"
-    echo " -H <host>        Base host part for curl call URLs"
-    echo " -I <project_id>  Project ID"
-    echo " -T <seconds>     Timeout"
+  echo "Usage: $0 [OPTIONS]"
+  echo " -h               Get help"
+  echo " -U <username>    Username to use for Horizon login"
+  echo " -P <password>    Password to use for Horizon login"
+  echo " -R <URL>         Region URL (Keystone endpoint)"
+  echo " -H <host>        Base host part for curl call URLs"
+  echo " -I <project_id>  Project ID"
+  echo " -T <seconds>     Timeout"
+}
+
+cleanup ()
+{
+  rm -f $COOKIE_FILE
+  rm -f $CSV_FILE
 }
 
 if (($# == 0)); then
@@ -98,6 +104,7 @@ $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME
 SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
 if [ "$SESSIONID" == "" ]; then
   echo "CRIT: Session ID not present on file $COOKIE_FILE |"
+  cleanup
   exit ${STATE_CRITICAL}
 fi
 
@@ -115,8 +122,7 @@ LOGIN_END=$(date +%s.%6N)
 LOGIN_TIME=$(echo "${LOGIN_END} - ${LOGIN_START}" | bc -l)
 LOGIN_TIME_INT=$(echo "${LOGIN_TIME}"|awk -F'.' '{print $1}')
 
-rm -f $COOKIE_FILE
-rm -f $CSV_FILE
+cleanup
 
 if [[ "${RETURNCODE}" -ne 0 ]]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -18,7 +18,7 @@ usage ()
     echo " -I <project_id>  Project ID"
 }
 
-while getopts 'h:H:U:T:P:' OPTION
+while getopts 'hU:P:R:H:I:' OPTION
 do
     case $OPTION in
         h)
@@ -59,6 +59,7 @@ HORIZON_USER="$HZ_TEST_USERNAME"
 HORIZON_PASSWORD="$HZ_TEST_PASSWORD"
 HORIZON_REGION="$HZ_TEST_REGION"
 HORIZON_HOST="$HZ_TEST_HOST"
+# If project ID is omitted, the check result will be based on whichever project Horizon picks for the user.
 HORIZON_PROJECT_ID="$HZ_TEST_PROJECT_ID"
 CSV_FILE=~/horizonresultfile
 DATE_START=$(date '+%Y-%m-%d')

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -119,7 +119,7 @@ $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME
 # Another approach would be to interpret curl output if you're keen on parsing XML.
 URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE --max-time $MAX_TIME -s "$URL"
-grep 'Usage Report' $CSV_FILE
+grep -q 'Usage Report' $CSV_FILE
 RETURNCODE=$?
 
 # Halt timer, see how long it took.

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -9,6 +9,11 @@ STATE_WARNING=1
 STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
+# Defaults: Curl timeout plus warn/crit thresholds
+MAX_TIME=60
+WARN=30
+CRIT=45
+
 usage ()
 {
     echo "Usage: $0 [OPTIONS]"
@@ -26,7 +31,7 @@ if (($# == 0)); then
   exit 1
 fi
 
-while getopts 'hU:P:R:H:I:' OPTION
+while getopts 'hU:P:R:H:I:w:c:' OPTION
 do
     case $OPTION in
         h)
@@ -51,6 +56,12 @@ do
         T)
             export MAX_TIME=$OPTARG
             ;;
+        w)
+            export WARN=$OPTARG
+            ;;
+        c)
+            export CRIT=$OPTARG
+            ;;
 	*)
             usage
             exit ${STATE_UNKNOWN}
@@ -60,7 +71,6 @@ done
 shift "$((OPTIND-1))"
 
 CURL="/bin/curl"
-MAX_TIME=60
 COOKIE_FILE=$(/usr/bin/mktemp)
 CSV_FILE=$(/usr/bin/mktemp)
 DATE_START=$(date '+%Y-%m-%d')
@@ -107,9 +117,18 @@ LOGIN_TIME=$( echo "${LOGIN_END} - ${LOGIN_START}" | bc -l )
 if [ "${RETURNCODE}" -ne 0 ]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "
   exit ${STATE_CRITICAL}
-else
+elif [ ${LOGIN_TIME} -gt $CRIT ]; then
+  echo "CRIT: - Login time exceeded $CRIT threshold |time=${LOGIN_TIME}s"
+  exit ${STATE_CRITICAL}
+elif [ ${LOGIN_TIME} -gt $WARN ]; then
+  echo "WARN: - Login time exceeded $WARN threshold |time=${LOGIN_TIME}s"
+  exit ${STATE_WARNING}
+elif [ "${RETURNCODE}" -eq 0 ]; then
   echo "OK: Login to Horizon was successful |time=${LOGIN_TIME}s"
   exit ${STATE_OK}
+else
+  echo "UNKNOWN: Script should not end up in this state."
+  exit ${STATE_UNKNOWN}
 fi
 
 rm -f $COOKIE_FILE

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -13,7 +13,7 @@ usage ()
     echo " -h               Get help"
     echo " -U <username>    Username to use for Horizon login"
     echo " -P <password>    Password to use for Horizon login"
-    echo " -R <URL>         Region URL"
+    echo " -R <URL>         Region URL (Keystone endpoint)"
     echo " -H <host>        Base host part for curl call URLs"
     echo " -I <project_id>  Project ID"
 }

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -65,8 +65,7 @@ CSV_FILE=~/horizonresultfile
 DATE_START=$(date '+%Y-%m-%d')
 DATE_END=$DATE_START
 
-# Bash builtin. Do not rename!
-SECONDS=0
+LOGIN_START=$(date +%s.%6N)
 
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
 TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
@@ -87,12 +86,13 @@ URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE -s "$URL"
 RETURNCODE=$?
 
-ELAPSED=$SECONDS
+LOGIN_END=$(date +%s.%6N)
+LOGIN_TIME=$( echo "${LOGIN_END} - ${LOGIN_START}" | bc -l )
 
 if [ "${RETURNCODE}" -ne 0 ]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "
   exit ${STATE_CRITICAL}
 else
-  echo "OK: Login to Horizon was successful |time=${ELAPSED}.0s"#TODO_LOGIN_TIMER
+  echo "OK: Login to Horizon was successful |time=${LOGIN_TIME}s"
   exit ${STATE_OK}
 fi

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -112,24 +112,25 @@ RETURNCODE=$?
 
 # Halt timer, see how long it took.
 LOGIN_END=$(date +%s.%6N)
-LOGIN_TIME=$( echo "${LOGIN_END} - ${LOGIN_START}" | bc -l )
+LOGIN_TIME=$(echo "${LOGIN_END} - ${LOGIN_START}" | bc -l)
+LOGIN_TIME_INT=$(echo "${LOGIN_TIME}"|awk -F'.' '{print $1}')
 
-if [ "${RETURNCODE}" -ne 0 ]; then
+rm -f $COOKIE_FILE
+rm -f $CSV_FILE
+
+if [[ "${RETURNCODE}" -ne 0 ]]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "
   exit ${STATE_CRITICAL}
-elif [ ${LOGIN_TIME} -gt $CRIT ]; then
-  echo "CRIT: - Login time exceeded $CRIT threshold |time=${LOGIN_TIME}s"
+elif [[ "${LOGIN_TIME_INT}" -gt "${CRIT}" ]]; then
+  echo "CRIT: - Login time exceeded ${CRIT} threshold |time=${LOGIN_TIME}s"
   exit ${STATE_CRITICAL}
-elif [ ${LOGIN_TIME} -gt $WARN ]; then
-  echo "WARN: - Login time exceeded $WARN threshold |time=${LOGIN_TIME}s"
+elif [[ "${LOGIN_TIME_INT}" -gt "${WARN}" ]]; then
+  echo "WARN: - Login time exceeded ${WARN} threshold |time=${LOGIN_TIME}s"
   exit ${STATE_WARNING}
-elif [ "${RETURNCODE}" -eq 0 ]; then
+elif [[ "${RETURNCODE}" -eq 0 ]]; then
   echo "OK: Login to Horizon was successful |time=${LOGIN_TIME}s"
   exit ${STATE_OK}
 else
   echo "UNKNOWN: Script should not end up in this state."
   exit ${STATE_UNKNOWN}
 fi
-
-rm -f $COOKIE_FILE
-rm -f $CSV_FILE

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -18,6 +18,11 @@ usage ()
     echo " -I <project_id>  Project ID"
 }
 
+if (($# == 0)); then
+  usage
+  exit 1
+fi
+
 while getopts 'hU:P:R:H:I:' OPTION
 do
     case $OPTION in
@@ -47,11 +52,6 @@ do
     esac
 done
 shift "$((OPTIND-1))"
-
-if (($# == 0)); then
-  usage
-  exit 1
-fi
 
 CURL="/bin/curl"
 COOKIE_FILE=~/horizontestcookie

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -14,7 +14,7 @@ usage ()
     echo " -U <username>    Username to use for Horizon login"
     echo " -P <password>    Password to use for Horizon login"
     echo " -R <URL>         Region URL"
-    echo " -H <hostname>    Hostname"
+    echo " -H <host>        Base host part for curl call URLs"
     echo " -I <project_id>  Project ID"
 }
 
@@ -23,7 +23,7 @@ do
     case $OPTION in
         h)
             usage
-            exit 0
+            exit ${STATE_UNKNOWN}
             ;;
         U)
             export HZ_TEST_USERNAME=$OPTARG
@@ -48,15 +48,19 @@ do
 done
 shift "$((OPTIND-1))"
 
+if (($# == 0)); then
+  usage
+  exit 1
+fi
 
 CURL="/bin/curl"
-COOKIE_FILE="~/horizontestcookie"
+COOKIE_FILE=~/horizontestcookie
 HORIZON_USER="$HZ_TEST_USERNAME"
 HORIZON_PASSWORD="$HZ_TEST_PASSWORD"
 HORIZON_REGION="$HZ_TEST_REGION"
 HORIZON_HOST="$HZ_TEST_HOST"
 HORIZON_PROJECT_ID="$HZ_TEST_PROJECT_ID"
-CSV_FILE="~/horizonresultfile"
+CSV_FILE=~/horizonresultfile
 DATE_START=$(date '+%Y-%m-%d')
 DATE_END=$DATE_START
 

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -65,6 +65,9 @@ CSV_FILE=~/horizonresultfile
 DATE_START=$(date '+%Y-%m-%d')
 DATE_END=$DATE_START
 
+# Bash builtin. Do not rename!
+SECONDS=0
+
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$HORIZON_HOST/dashboard/auth/login/?next=/dashboard/"
 TOKEN=$(cat $COOKIE_FILE | grep csrftoken | sed 's/^.*csrftoken\s*//')
 
@@ -82,13 +85,14 @@ $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null -s "$TENANT_URL"
 
 URL="$HORIZON_HOST/dashboard/project/?start=$DATE_START&end=$DATE_END&format=csv"
 $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output $CSV_FILE -s "$URL"
-
 RETURNCODE=$?
+
+ELAPSED=$SECONDS
 
 if [ "${RETURNCODE}" -ne 0 ]; then
   echo "CRIT: Unable to login to Horizon and perform actions | "
   exit ${STATE_CRITICAL}
 else
-  echo "OK: Login to Horizon was successful | " # TODO_LOGIN_TIMER
+  echo "OK: Login to Horizon was successful |time=${ELAPSED}.0s"#TODO_LOGIN_TIMER
   exit ${STATE_OK}
 fi

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # Check if Horizon login works externally (outside of haproxy)
+#
+# Adapted from a script by https://ask.openstack.org/en/users/17403/amedeo-salvati/
 
 STATE_OK=0
 STATE_WARNING=1

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -96,3 +96,6 @@ else
   echo "OK: Login to Horizon was successful |time=${LOGIN_TIME}s"
   exit ${STATE_OK}
 fi
+
+rm $COOKIE_FILE
+rm $CSV_FILE

--- a/files/nrpe/check_horizon_ext
+++ b/files/nrpe/check_horizon_ext
@@ -97,8 +97,8 @@ $CURL -L -c $COOKIE_FILE -b $COOKIE_FILE --output /dev/null --max-time $MAX_TIME
 # Check that we actually got a proper login session.
 SESSIONID=$(cat $COOKIE_FILE | grep sessionid | sed 's/^.*sessionid\s*//')
 if [ "$SESSIONID" == "" ]; then
-    echo "Error: sessionid not present on file $COOKIE_FILE"
-    exit 1
+  echo "CRIT: Session ID not present on file $COOKIE_FILE |"
+  exit ${STATE_CRITICAL}
 fi
 
 # Switch project context if interested in some particular project.

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -149,6 +149,7 @@ command[check_postgres]=/usr/lib64/nagios/plugins/check_postgres $ARG1$
 command[check_raid]=/usr/lib64/nagios/plugins/check_raid $ARG1$
 command[check_time_skew]=/usr/lib64/nagios/plugins/check_time_skew $ARG1$
 command[check_cpu]=<%= @nrpe_local_script_path %>/check_cpu $ARG1$
+command[check_http]=/usr/lib64/nagios/plugins/check_http $ARG1$
 
 # INCLUDE CONFIG DIRECTORY
 # This directive allows you to include definitions from config files (with a


### PR DESCRIPTION
This supports two new checks in Opsview

1) "CCCP - Horizon - HAProxy external" a new script to test Horizon login time.
2) "CCCP - Horizon - API node local" riding on check_http to test Horizon pageload from localhost, behind haproxy.

