### PR TITLE
Add Nagios check for L3 agents

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -692,6 +692,7 @@ class OSL3Agent():
     self.neutron = neutronclient.Client('2', session=keystone_session_v3(options))
 
   def check_bad_l3_agents(self):
+    err_l3agents = []
     l3agents = self.neutron.list_agents(agent_type='L3 agent')
 
     if str(l3agents.keys()) == "[u'agents']":
@@ -701,19 +702,23 @@ class OSL3Agent():
             OK = 1
           elif x['alive'] == False and x['admin_state_up'] == False:
             WARNING = 1
+            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
           elif x['alive'] == False and x['admin_state_up'] == True:
             CRITICAL = 1
+            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
           else:
             UNKNOWN = 1
+            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
     else:
       UNKNOWN = 1
+      err_l3agents = l3agents
 
     if CRITICAL == 1:
-      raise NeutronL3AgentsCritical(msgs=l3agents)
+      raise NeutronL3AgentsCritical(msgs=err_l3agents)
     elif WARNING == 1:
-      raise NeutronL3AgentsWarning(msgs=l3agents)
+      raise NeutronL3AgentsWarning(msgs=err_l3agents)
     elif UNKNOWN == 1:
-      raise NeutronL3AgentsUnknown(msgs=l3agents)
+      raise NeutronL3AgentsUnknown(msgs=err_l3agents)
     else:
       logging.info('All running L3 agents are alive')
 

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -1195,7 +1195,7 @@ def parse_command_line():
   Parse command line and execute check according to command line arguments
   '''
   usage = '%prog { instance | volume | ghostinstance | ghostvolumessh | ghostvolume| ghostnodes | l3agent' \
-          '| capacity | barbican | cinder | glance | heat | keystone | magnum | neutron | nova }'
+          ' | capacity | barbican | cinder | glance | heat | keystone | magnum | neutron | nova }'
   parser = optparse.OptionParser(usage)
   parser.add_option("-a", "--auth_url", dest='auth_url', help='identity endpoint URL')
   parser.add_option("-u", "--username", dest='username', help='username')

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -702,13 +702,13 @@ class OSL3Agent():
             OK = 1
           elif x['alive'] == False and x['admin_state_up'] == False:
             WARNING = 1
-            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
+            err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (x['binary'],x['admin_state_up'],x['alive'],x['host']))
           elif x['alive'] == False and x['admin_state_up'] == True:
             CRITICAL = 1
-            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
+            err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (x['binary'],x['admin_state_up'],x['alive'],x['host']))
           else:
             UNKNOWN = 1
-            err_l3agents.append("%s on %s" % (x['binary'],x['host']))
+            err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (x['binary'],x['admin_state_up'],x['alive'],x['host']))
     else:
       UNKNOWN = 1
       err_l3agents = l3agents

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -685,6 +685,9 @@ class OSL3Agent():
   '''
   Check all Neutron L3 agents are alive
   '''
+
+  options = dict()
+
   def __init__(self, options):
     self.neutron = neutronclient.Client('2', session=keystone_session_v3(options))
 
@@ -694,8 +697,6 @@ class OSL3Agent():
     if str(l3agents.keys()) == "[u'agents']":
       for item in l3agents.values():
         for x in item:
-          print(x['alive'])
-          print(x['admin_state_up'])
           if x['alive'] == True and x['admin_state_up'] == True:
             OK = 1
           elif x['alive'] == False and x['admin_state_up'] == False:
@@ -708,13 +709,10 @@ class OSL3Agent():
       UNKNOWN = 1
 
     if CRITICAL == 1:
-      print('CRIT!!!!!!!!!!!')
       raise NeutronL3AgentsCritical(msgs=l3agents)
     elif WARNING == 1:
-      print('WARN!!!!!!!!!!!')
       raise NeutronL3AgentsWarning(msgs=l3agents)
     elif UNKNOWN == 1:
-      print('UNKNOWN!!!!!!!!!!!')
       raise NeutronL3AgentsUnknown(msgs=l3agents)
     else:
       logging.info('All running L3 agents are alive')
@@ -729,7 +727,7 @@ class OSVolumeErrorCheck():
   ''' Ghosthunting for volumes in "error " state. '''
 
   options = dict()
-	
+
   def __init__(self, options):
     self.options = options
     self.cinder = cinderclient.client.Client('3', session=keystone_session_v3(options))


### PR DESCRIPTION
We haven't monitored neutron L3 agents which has caused situations where customer notices problem and we are aware of it only after they report it to us.
This change implements a nagios check which checks all known neutron L3 agent statuses from openstack by comparing alive and admin_state_up properties and reports for inconsistencies.

Relates to CCCP-4143