### PR TITLE
Bugfix for CCCP-4143

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -693,6 +693,8 @@ class OSL3Agent():
 
   def check_bad_l3_agents(self):
     err_l3agents = list()
+    OK = WARNING = CRITICAL = UNKNOWN = 0
+
     l3agents = self.neutron.list_agents(agent_type='L3 agent')
 
     if 'agents' in l3agents:


### PR DESCRIPTION
Initialize variables first before checks
Bug was found when code was deployed to test environment which had no active alarms. This variable initialization before checking any values from variables fixes it.