### PR TITLE
Modify check_keystone to fit opsview trimming

### DIFF
--- a/files/nrpe/check_keystone
+++ b/files/nrpe/check_keystone
@@ -132,8 +132,6 @@ class CheckKeystone(keystone.Client):
       if role.id in roles_per_id:
         # Genertate string for def csc_stats
         return_string += " 'role_" + str(role.name) + "'=" + str(roles_per_id[role.id])
-      else:
-        return_string += " 'role_" + str(role.name) + "'=" + "0"
     return(return_string)
 
 def exit_output(exit_code=NAGIOS_STATE_OK, output=''):


### PR DESCRIPTION
Opsview performance data goes through a normalization process, which tries to sanitize host, service and metrics names: convert to lowercase, remove problematic characters, replace whitespaces with underscores. This process then often ends up with multiple consequent underscores, which get replaced with a single underscore character, or trailing underscores, which get stripped.