### PR TITLE
Improve L3 agents check

### DIFF
--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -716,14 +716,16 @@ class OSL3Agent():
                                                                           agent['alive'],
                                                                           agent['host']))
 
-        elif (
-             (agent['alive'] == True and agent['admin_state_up'] == False) and
-             (not (agent['configurations']['ex_gw_ports'] == 0) or
+        elif agent['alive'] == True and agent['admin_state_up'] == False:
+          if (
+             not (agent['configurations']['ex_gw_ports'] == 0) or
              not (agent['configurations']['floating_ips'] == 0) or
              not (agent['configurations']['interfaces'] == 0) or
              not (agent['configurations']['routers'] == 0))
              ):
-          CRITICAL = 1
+            CRITICAL = 1
+          else:
+            OK = 1
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
                                                                             agent['binary'],
                                                                             agent['admin_state_up'],

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -716,20 +716,18 @@ class OSL3Agent():
                                                                           agent['alive'],
                                                                           agent['host']))
         elif agent['alive'] == True and agent['admin_state_up'] == False:
-          if (
-               not (agent['configurations']['ex_gw_ports'] == 0) or
-               not (agent['configurations']['floating_ips'] == 0) or
-               not (agent['configurations']['interfaces'] == 0) or
-               not (agent['configurations']['routers'] == 0)
-             ):
-            CRITICAL = 1
-            err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                              agent['binary'],
-                                                                              agent['admin_state_up'],
-                                                                              agent['alive'],
-                                                                              agent['host']))
-          else:
-            OK = 1
+          ports = self.neutron.list_ports()
+          for port in ports['ports']:
+            if port['binding:host_id'] == agent['host']:
+              CRITICAL = 1
+              err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
+                                                                                agent['binary'],
+                                                                                agent['admin_state_up'],
+                                                                                agent['alive'],
+                                                                                agent['host']))
+              break
+            else:
+              OK = 1
         else:
           UNKNOWN = 1
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -715,13 +715,12 @@ class OSL3Agent():
                                                                           agent['admin_state_up'],
                                                                           agent['alive'],
                                                                           agent['host']))
-
         elif agent['alive'] == True and agent['admin_state_up'] == False:
           if (
-             not (agent['configurations']['ex_gw_ports'] == 0) or
-             not (agent['configurations']['floating_ips'] == 0) or
-             not (agent['configurations']['interfaces'] == 0) or
-             not (agent['configurations']['routers'] == 0))
+               not (agent['configurations']['ex_gw_ports'] == 0) or
+               not (agent['configurations']['floating_ips'] == 0) or
+               not (agent['configurations']['interfaces'] == 0) or
+               not (agent['configurations']['routers'] == 0)
              ):
             CRITICAL = 1
           else:
@@ -731,7 +730,6 @@ class OSL3Agent():
                                                                             agent['admin_state_up'],
                                                                             agent['alive'],
                                                                             agent['host']))
-
         else:
           UNKNOWN = 1
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -715,6 +715,21 @@ class OSL3Agent():
                                                                           agent['admin_state_up'],
                                                                           agent['alive'],
                                                                           agent['host']))
+
+        elif (
+             (agent['alive'] == True and agent['admin_state_up'] == False) and
+             (not (agent['configurations']['ex_gw_ports'] == 0) or
+             not (agent['configurations']['floating_ips'] == 0) or
+             not (agent['configurations']['interfaces'] == 0) or
+             not (agent['configurations']['routers'] == 0))
+             ):
+          CRITICAL = 1
+          err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
+                                                                            agent['binary'],
+                                                                            agent['admin_state_up'],
+                                                                            agent['alive'],
+                                                                            agent['host']))
+
         else:
           UNKNOWN = 1
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -703,38 +703,22 @@ class OSL3Agent():
           OK = 1
         elif agent['alive'] == False and agent['admin_state_up'] == False:
           WARNING = 1
-          err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                          agent['binary'],
-                                                                          agent['admin_state_up'],
-                                                                          agent['alive'],
-                                                                          agent['host']))
         elif agent['alive'] == False and agent['admin_state_up'] == True:
           CRITICAL = 1
-          err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                          agent['binary'],
-                                                                          agent['admin_state_up'],
-                                                                          agent['alive'],
-                                                                          agent['host']))
         elif agent['alive'] == True and agent['admin_state_up'] == False:
-          ports = self.neutron.list_ports()
-          for port in ports['ports']:
-            if port['binding:host_id'] == agent['host']:
-              CRITICAL = 1
-              err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                                agent['binary'],
-                                                                                agent['admin_state_up'],
-                                                                                agent['alive'],
-                                                                                agent['host']))
-              break
-            else:
-              OK = 1
+          ports = self.neutron.list_ports(**{"binding:host_id" : agent['host'], "device_owner" : ["network:router_gateway", "network:router_interface"]})
+          if ports['ports']:
+            CRITICAL = 1
+          else:
+            OK = 1
         else:
           UNKNOWN = 1
+        if WARNING > 0 or CRITICAL > 0 or UNKNOWN > 0:
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                          agent['binary'],
-                                                                          agent['admin_state_up'],
-                                                                          agent['alive'],
-                                                                          agent['host']))
+                                                                  agent['binary'],
+                                                                  agent['admin_state_up'],
+                                                                  agent['alive'],
+                                                                  agent['host']))
     else:
       raise NeutronL3AgentsUnknown(msgs=l3agents)
 

--- a/files/nrpe/check_openstack.py
+++ b/files/nrpe/check_openstack.py
@@ -723,13 +723,13 @@ class OSL3Agent():
                not (agent['configurations']['routers'] == 0)
              ):
             CRITICAL = 1
+            err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
+                                                                              agent['binary'],
+                                                                              agent['admin_state_up'],
+                                                                              agent['alive'],
+                                                                              agent['host']))
           else:
             OK = 1
-          err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (
-                                                                            agent['binary'],
-                                                                            agent['admin_state_up'],
-                                                                            agent['alive'],
-                                                                            agent['host']))
         else:
           UNKNOWN = 1
           err_l3agents.append("%s (admin_state_up=%s, alive=%s) on %s" % (


### PR DESCRIPTION
Improve L3 agents check so that it will catch admin disabled agents which still report ports, floating_ips, interfaces or routers.

* CCCP-4702